### PR TITLE
NAT-301: allow EPiServer to find vacancies by location search

### DIFF
--- a/app/controllers/api/v0/serialisers.rb
+++ b/app/controllers/api/v0/serialisers.rb
@@ -2,6 +2,7 @@
 
 module Api
   module V0
+    # rubocop:disable Metrics/ModuleLength
     module Serialisers
       private
 
@@ -63,6 +64,20 @@ module Api
         }
       end
 
+      def vacancy_as_v0_json_with_distance(office, location)
+        vacancy = vacancy_as_v0_json(office)
+        vacancy[:distance] = distance_in_miles(location, office.location)
+        vacancy
+      end
+
+      def distance_in_miles(location1, location2)
+        if location1.nil? || location2.nil?
+          0
+        else
+          location1.distance(location2) / 1609.34
+        end
+      end
+
       def address_block(office, include_local_authority:)
         block = {
           address: office.street,
@@ -73,8 +88,10 @@ module Api
           latLong: [office.location.y, office.location.x]
         }
         if include_local_authority
-          block.update({          onsDistrictCode: office.local_authority&.id,
-                                  localAuthority: office.local_authority&.name })
+          block.update({
+            onsDistrictCode: office.local_authority&.id,
+            localAuthority: office.local_authority&.name
+          })
         end
         block
       end
@@ -105,5 +122,6 @@ module Api
         [{ contact: value, description: nil }]
       end
     end
+    # rubocop:enable Metrics/ModuleLength
   end
 end

--- a/app/controllers/api/v0/vacancy_controller.rb
+++ b/app/controllers/api/v0/vacancy_controller.rb
@@ -14,7 +14,14 @@ module Api
       end
 
       def list
-        head :not_implemented
+        offices, normalised_location = Office.search_by_location(params[:near], only_with_vacancies: true)
+        render json: { type: "vacancies", list: offices.map { |office| vacancy_as_v0_json_with_distance(office, normalised_location) } }
+      rescue Office::SearchNoResultsError
+        render json: { type: "no results" }
+      rescue Office::SearchOutOfAreaError => e
+        render json: { type: "Out of bounds #{e.country}" }
+      rescue Office::SearchAmbiguousError => e
+        render json: { type: "locality", list: e.options }
       end
     end
   end

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Office < ApplicationRecord
+  attribute :location, :st_point, srid: 4326, geographic: true
   attribute :opening_hours_monday, TimerangeType.new
   attribute :opening_hours_tuesday, TimerangeType.new
   attribute :opening_hours_wednesday, TimerangeType.new
@@ -50,6 +51,39 @@ class Office < ApplicationRecord
     end
   end
   # rubocop:enable Metrics/AbcSize
+
+  def self.search_by_location(near, opts)
+    opts[:only_with_vacancies] ||= false
+
+    postcode = Postcode.normalise_and_find(near)
+    raise SearchNoResultsError if postcode.nil?
+
+    q = Office.limit(10)
+    q.order(Office.arel_table[:location].st_distance(postcode.location))
+    q = q.where.not(volunteer_roles: []) if opts[:only_with_vacancies]
+    [q, postcode.location]
+  end
+
+  class SearchNoResultsError < StandardError
+  end
+
+  class SearchOutOfAreaError < StandardError
+    attr_reader :country
+
+    def initialize(msg, country)
+      @country = country
+      super(msg)
+    end
+  end
+
+  class SearchAmbiguousError < StandardError
+    attr_reader :options
+
+    def initialize(msg, options)
+      @options = options
+      super(msg)
+    end
+  end
 
   private
 

--- a/app/models/postcode.rb
+++ b/app/models/postcode.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Postcode < ApplicationRecord
+  attribute :location, :st_point, srid: 4326, geographic: true
   belongs_to :local_authority
 
   def self.normalise_and_find(postcode)

--- a/spec/lss_loader_spec.rb
+++ b/spec/lss_loader_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe LssLoader do
 
     # Think the lat and lon look backwards? that's because in GIS coordinates are expressed in
     # x,y terms, not lat, lon. Therefore the lon comes first.
-    expect(Office.first.location).to eq RGeo::Cartesian.preferred_factory.point(1.18184, 51.07988)
+    expect(Office.first.location.as_text).to eq "POINT (1.18184 51.07988)"
   end
 
   it "loads in accessibility information as list" do


### PR DESCRIPTION
Initially this is postcode only, but as it's implemented as a helper function it'll be shared logic with Find Your Local Citizens Advice. There are a number of assumptions made at the moment that will need to be revisted when product decisions get fleshed out, e.g., number of results, should there be a max distance, etc.