### PR TITLE
NAT-318: allow fuzzy searching, matching on local authority and LCA names

### DIFF
--- a/app/controllers/api/v1/office_controller.rb
+++ b/app/controllers/api/v1/office_controller.rb
@@ -32,13 +32,13 @@ module Api
       end
 
       def search_response(query)
-        offices, = OfficeSearch.by_location query, only_in_same_local_authority: true
+        offices, normalised_location = OfficeSearch.by_location query, only_in_same_local_authority: true
       rescue OfficeSearch::UnknownLocationError
         { match_type: "unknown", results: [] }
       rescue OfficeSearch::OutOfAreaError => e
         { match_type: "out_of_area_#{e.country}", results: [] }
       else
-        { match_type: "exact", results: offices.map { |office| { id: office.id } } }
+        { match_type: normalised_location.nil? ? "fuzzy" : "exact", results: offices.map { |office| { id: office.id, name: office.name } } }
       end
 
       def fetch_and_render_office

--- a/lib/office_search.rb
+++ b/lib/office_search.rb
@@ -1,13 +1,17 @@
 # frozen_string_literal: true
 
 module OfficeSearch
-  def self.by_location(near, opts)
+  def self.by_location(near, opts = {})
     opts[:only_with_vacancies] ||= false
     opts[:only_in_same_local_authority] ||= false
 
-    location, local_authority_id = find_location(near)
-
-    [build_query(location, local_authority_id, opts), location]
+    exact_location_results = find_exact_location(near)
+    if exact_location_results.nil?
+      [by_fuzzy_location(near, opts), nil]
+    else
+      location, local_authority_id = exact_location_results
+      [build_query_from_location(location, local_authority_id, opts), location]
+    end
   end
 
   class UnknownLocationError < StandardError
@@ -33,16 +37,16 @@ module OfficeSearch
     end
   end
 
-  def self.find_location(near)
+  def self.find_exact_location(near)
     postcode = Postcode.normalise_and_find(near)
-    raise UnknownLocationError if postcode.nil?
+    return nil if postcode.nil?
     raise OutOfAreaError, :ni if postcode.northern_irish?
     raise OutOfAreaError, :scotland if postcode.scottish?
 
     [postcode.location, postcode.local_authority_id]
   end
 
-  def self.build_query(location, local_authority_id, opts)
+  def self.build_query_from_location(location, local_authority_id, opts)
     q = Office.all
     q = if opts[:only_in_same_local_authority]
           q.where(local_authority_id:)
@@ -52,5 +56,20 @@ module OfficeSearch
 
     q = q.where.not(volunteer_roles: []) if opts[:only_with_vacancies]
     q.order(Office.arel_table[:location].st_distance(location))
+  end
+
+  def self.by_fuzzy_location(near, opts)
+    fuzzy_query = build_fuzzy_query(near, opts)
+    raise UnknownLocationError if fuzzy_query.empty?
+
+    fuzzy_query
+  end
+
+  def self.build_fuzzy_query(near, opts)
+    office_with_local_authorities = Office.left_outer_joins(:local_authority)
+    q = office_with_local_authorities.where(Office.arel_table[:name].matches("%#{near}%"))
+    q = q.or(office_with_local_authorities.where(LocalAuthority.arel_table[:name].matches("%#{near}%")))
+    q = q.where.not(volunteer_roles: []) if opts[:only_with_vacancies]
+    q.limit(10)
   end
 end

--- a/spec/office_search_spec.rb
+++ b/spec/office_search_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "office_search"
+
+RSpec.describe OfficeSearch do
+  it "only returns LCAs in the area when specified" do
+    in_area_office = create_office_with_local_authority
+    create_office_with_local_authority "X0001235", "Testtown"
+    create_postcode "XX4 6LA", in_area_office.local_authority_id
+
+    results, = described_class.by_location("XX4 6LA", only_in_same_local_authority: true)
+
+    expect(results.pluck(:id)).to contain_exactly(in_area_office.id)
+  end
+
+  it "returns all the LCAs in an area when it's a fuzzy match that matches on local authority names" do
+    office = create_office_with_local_authority
+    other_office = create_office name: "Another Citizens Advice", local_authority_id: office.local_authority_id
+
+    results, = described_class.by_location("test")
+
+    expect(results.pluck(:id)).to contain_exactly(office.id, other_office.id)
+  end
+
+  it "returns all LCAs which have a fuzzy match on the LCA name" do
+    office = create_office_with_local_authority
+    other_office = create_office name: "Anotherville Citizens Advice", local_authority_id: office.local_authority_id
+
+    results, = described_class.by_location("anotherville")
+
+    expect(results.pluck(:id)).to contain_exactly(other_office.id)
+  end
+
+  it "returns both a mix of if the office name matches and if the local authority matches" do
+    office = create_office_with_local_authority
+    other_office = create_office name: "Testtown Citizens Advice"
+
+    results, = described_class.by_location("test")
+
+    expect(results.pluck(:id)).to contain_exactly(office.id, other_office.id)
+  end
+
+  it "ensures fuzzy matches respect the only with vacancies flag" do
+    office = create_office_with_local_authority
+    office_with_roles = create_office name: "Another Citizens Advice", local_authority_id: office.local_authority_id,
+                                      volunteer_roles: ["trustee"]
+
+    results, = described_class.by_location("test", only_with_vacancies: true)
+
+    expect(results.pluck(:id)).to contain_exactly(office_with_roles.id)
+  end
+
+  def create_office_with_local_authority(la_id = "X0001234", la_name = "Testshire")
+    local_authority_id = LocalAuthority.create!(id: la_id, name: la_name).id
+    create_office name: "#{la_name} Citizens Advice", local_authority_id:
+  end
+
+  def create_office(vals = {})
+    Office.create!({ id: generate_salesforce_id, office_type: :office, name: "Testtown Citizens Advice" }.update(vals))
+  end
+
+  def create_postcode(canonical, local_authority_id = "X0001234")
+    Postcode.create! canonical:, local_authority_id:, location: "POINT(-0.78 52.66)"
+  end
+end


### PR DESCRIPTION
Although most users search using their postcode, a smaller number of users will search based on a place name. In order to accomodate these, we can do a simple search matching both on LCA name and local authority name.

Checking based on current usage data, we think this gets us to a high degree of coverage, without having to implement a full geocoding solution for MVP.