### PR TITLE
NAT-301: fetch office API is also required for Episerver volunteer form submission

### DIFF
--- a/app/controllers/api/v0/location_controller.rb
+++ b/app/controllers/api/v0/location_controller.rb
@@ -3,8 +3,12 @@
 module Api
   module V0
     class LocationController < BaseController
+      include Serialisers
       def get
-        head :not_implemented
+        office = Office.find_by!(legacy_id: params[:id], office_type: :office)
+        render json: location_as_v0_json(office)
+      rescue ActiveRecord::RecordNotFound
+        head :not_found
       end
 
       def list

--- a/spec/requests/v0/location_spec.rb
+++ b/spec/requests/v0/location_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "swagger_helper"
+require_relative "schema"
 
 RSpec.describe "Bureau Details legacy API - Locations", swagger_doc: "v0/swagger.yaml" do
   include_context "with episerver credentials"
@@ -11,8 +12,206 @@ RSpec.describe "Bureau Details legacy API - Locations", swagger_doc: "v0/swagger
       security [basic_auth: []]
       parameter name: :serial_number, in: :path, type: :string, description: "{serial_number} is the locations serial number."
 
-      response "501", "is a deprecated API which has not been reimplemented" do
-        let(:serial_number) { "10002" }
+      response "200", "fetches all data for an office" do
+        schema BureauDetailsSchema::OFFICE_SCHEMA
+
+        # this comes from the original fixture data provided in bureau-details
+        # https://github.com/citizensadvice/rd-bureau-details-web-service/blob/master/BureauDetailsService/TestMember.cs
+        let(:local_authority) { LocalAuthority.create! id: "E05XXTEST", name: "Borsetshire" }
+
+        let(:member) do
+          Office.new(id: generate_salesforce_id,
+                     legacy_id: 1,
+                     membership_number: "55/5555",
+                     office_type: :member,
+                     name: "Citizens Advice Felpersham",
+                     company_number: "12345678",
+                     charity_number: "87654321",
+                     street: "14 Shakespeare Road",
+                     city: "Felpersham",
+                     postcode: "FX1 7QW",
+                     location: "POINT(-0.7646468 52.0451619)",
+                     local_authority:)
+        end
+
+        let(:office) do
+          Office.new(id: generate_salesforce_id,
+                     parent: member,
+                     name: "Citizens Advice Felpersham North",
+                     street: "14 Shakespeare Road",
+                     city: "Felpersham",
+                     postcode: "FX1 7QW",
+                     location: "POINT(-0.7646468 52.0451619)",
+                     legacy_id: 2,
+                     membership_number: "55/5555",
+                     office_type: :office,
+                     about_text: "This is not a real Citizens Advice bureau.",
+                     accessibility_information: ["Wheelchair accessible", "Wheelchair toilet access",
+                                                 "Internet advice access"],
+                     volunteer_roles: ["admin_and_customer_service"],
+                     opening_hours_information: "Self help computers 9am to 4pm",
+                     opening_hours_monday: Tod::Shift.new(Tod::TimeOfDay.new(10), Tod::TimeOfDay.new(12, 30)),
+                     opening_hours_tuesday: Tod::Shift.new(Tod::TimeOfDay.new(10), Tod::TimeOfDay.new(12, 30)),
+                     opening_hours_wednesday: Tod::Shift.new(Tod::TimeOfDay.new(13, 30), Tod::TimeOfDay.new(16)),
+                     opening_hours_thursday: Tod::Shift.new(Tod::TimeOfDay.new(10), Tod::TimeOfDay.new(16)),
+                     opening_hours_friday: Tod::Shift.new(Tod::TimeOfDay.new(10), Tod::TimeOfDay.new(16)),
+                     telephone_advice_hours_monday: Tod::Shift.new(Tod::TimeOfDay.new(10), Tod::TimeOfDay.new(16)),
+                     telephone_advice_hours_tuesday: Tod::Shift.new(Tod::TimeOfDay.new(10), Tod::TimeOfDay.new(16)),
+                     telephone_advice_hours_wednesday: Tod::Shift.new(Tod::TimeOfDay.new(10), Tod::TimeOfDay.new(16)),
+                     telephone_advice_hours_thursday: Tod::Shift.new(Tod::TimeOfDay.new(10), Tod::TimeOfDay.new(16)),
+                     telephone_advice_hours_friday: Tod::Shift.new(Tod::TimeOfDay.new(10), Tod::TimeOfDay.new(16)),
+                     email: "felphersham@example.com",
+                     website: "http://www.felpershamcab.org.uk",
+                     phone: "01632 555 555",
+                     local_authority:)
+        end
+
+        let(:serial_number) do
+          office.legacy_id
+        end
+
+        before do
+          member.save
+          office.save
+        end
+
+        # rubocop:disable RSpec/ExampleLength
+        run_test! do |response|
+          expect(JSON.parse(response.body, symbolize_names: true)).to eq({
+            address: {
+              address: "14 Shakespeare Road",
+              town: "Felpersham",
+              county: nil,
+              postcode: "FX1 7QW",
+              onsDistrictCode: "E05XXTEST",
+              localAuthority: "Borsetshire",
+              latLong: [52.0451619, -0.7646468]
+            },
+            membershipNumber: "55/5555",
+            name: "Citizens Advice Felpersham North",
+            serialNumber: "2",
+            inVCC: true,
+            isBureau: true,
+            isOutlet: false,
+            features: [
+              "Wheelchair accessible",
+              "Wheelchair toilet access",
+              "Internet advice access"
+            ],
+            notes: "This is not a real Citizens Advice bureau.",
+            openingTimes: [
+              {
+                day: "Monday",
+                start1: "10.00",
+                end1: "12.30",
+                start2: nil,
+                end2: nil,
+                notes: "Self help computers 9am to 4pm"
+              },
+              {
+                day: "Tuesday",
+                start1: "10.00",
+                end1: "12.30",
+                start2: nil,
+                end2: nil,
+                notes: "Self help computers 9am to 4pm"
+              },
+              {
+                day: "Wednesday",
+                start1: "13.30",
+                end1: "16.00",
+                start2: nil,
+                end2: nil,
+                notes: "Self help computers 9am to 4pm"
+              },
+              {
+                day: "Thursday",
+                start1: "10.00",
+                end1: "16.00",
+                start2: nil,
+                end2: nil,
+                notes: "Self help computers 9am to 4pm"
+              },
+              {
+                day: "Friday",
+                start1: "10.00",
+                end1: "16.00",
+                start2: nil,
+                end2: nil,
+                notes: "Self help computers 9am to 4pm"
+              }
+            ],
+            publicContacts: {
+              email: [
+                {
+                  contact: "felphersham@example.com",
+                  description: nil
+                }
+              ],
+              fax: [],
+              minicom: [],
+              telephone: [
+                {
+                  contact: "01632 555 555",
+                  description: nil
+                }
+              ],
+              website: [
+                {
+                  contact: "http://www.felpershamcab.org.uk",
+                  description: nil
+                }
+              ]
+            },
+            telephoneTimes: [
+              {
+                day: "Monday",
+                start1: "10.00",
+                end1: "16.00",
+                start2: nil,
+                end2: nil,
+                notes: nil
+              },
+              {
+                day: "Tuesday",
+                start1: "10.00",
+                end1: "16.00",
+                start2: nil,
+                end2: nil,
+                notes: nil
+              },
+              {
+                day: "Wednesday",
+                start1: "10.00",
+                end1: "16.00",
+                start2: nil,
+                end2: nil,
+                notes: nil
+              },
+              {
+                day: "Thursday",
+                start1: "10.00",
+                end1: "16.00",
+                start2: nil,
+                end2: nil,
+                notes: nil
+              },
+              {
+                day: "Friday",
+                start1: "10.00",
+                end1: "16.00",
+                start2: nil,
+                end2: nil,
+                notes: nil
+              }
+            ]
+          })
+        end
+        # rubocop:enable RSpec/ExampleLength
+      end
+
+      response "404", "when no office with that serial number is found" do
+        let(:serial_number) { "404" }
 
         run_test!
       end

--- a/swagger/v0/swagger.yaml
+++ b/swagger/v0/swagger.yaml
@@ -17,8 +17,254 @@ paths:
         schema:
           type: string
       responses:
-        '501':
-          description: is a deprecated API which has not been reimplemented
+        '200':
+          description: fetches all data for an office
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  address:
+                    type: object
+                    properties:
+                      onsDistrictCode:
+                        type: string
+                      localAuthority:
+                        type: string
+                      address:
+                        type: string
+                      town:
+                        type: string
+                      county:
+                        type:
+                        - string
+                        - 'null'
+                      postcode:
+                        type:
+                        - string
+                        - 'null'
+                      latLong:
+                        type: array
+                        items:
+                          type: number
+                        minItems: 2
+                        maxItems: 2
+                    required:
+                    - address
+                    - town
+                    - county
+                    - postcode
+                    - latLong
+                    - onsDistrictCode
+                    - localAuthority
+                    additionalProperties: false
+                  membershipNumber:
+                    type: string
+                  name:
+                    type: string
+                  serialNumber:
+                    type: string
+                  inVCC:
+                    type: boolean
+                  isBureau:
+                    type: boolean
+                  isOutlet:
+                    type: boolean
+                  features:
+                    type: array
+                    items:
+                      type: string
+                  notes:
+                    type:
+                    - string
+                    - 'null'
+                  openingTimes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        day:
+                          type: string
+                          enum:
+                          - Monday
+                          - Tuesday
+                          - Wednesday
+                          - Thursday
+                          - Friday
+                          - Saturday
+                          - Sunday
+                        start1:
+                          type:
+                          - string
+                          - 'null'
+                        end1:
+                          type:
+                          - string
+                          - 'null'
+                        start2:
+                          type:
+                          - string
+                          - 'null'
+                        end2:
+                          type:
+                          - string
+                          - 'null'
+                        notes:
+                          type:
+                          - string
+                          - 'null'
+                      required:
+                      - day
+                      - start1
+                      - end1
+                      - start2
+                      - end2
+                      - notes
+                      additionalProperties: false
+                  publicContacts:
+                    type: object
+                    properties:
+                      email:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            contact:
+                              type: string
+                            description:
+                              type:
+                              - string
+                              - 'null'
+                          required:
+                          - contact
+                          - description
+                          additionalProperties: false
+                      fax:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            contact:
+                              type: string
+                            description:
+                              type:
+                              - string
+                              - 'null'
+                          required:
+                          - contact
+                          - description
+                          additionalProperties: false
+                      minicom:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            contact:
+                              type: string
+                            description:
+                              type:
+                              - string
+                              - 'null'
+                          required:
+                          - contact
+                          - description
+                          additionalProperties: false
+                      telephone:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            contact:
+                              type: string
+                            description:
+                              type:
+                              - string
+                              - 'null'
+                          required:
+                          - contact
+                          - description
+                          additionalProperties: false
+                      website:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            contact:
+                              type: string
+                            description:
+                              type:
+                              - string
+                              - 'null'
+                          required:
+                          - contact
+                          - description
+                          additionalProperties: false
+                    required:
+                    - email
+                    - fax
+                    - minicom
+                    - telephone
+                    - website
+                    additionalProperties: false
+                  telephoneTimes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        day:
+                          type: string
+                          enum:
+                          - Monday
+                          - Tuesday
+                          - Wednesday
+                          - Thursday
+                          - Friday
+                          - Saturday
+                          - Sunday
+                        start1:
+                          type:
+                          - string
+                          - 'null'
+                        end1:
+                          type:
+                          - string
+                          - 'null'
+                        start2:
+                          type:
+                          - string
+                          - 'null'
+                        end2:
+                          type:
+                          - string
+                          - 'null'
+                        notes:
+                          type:
+                          - string
+                          - 'null'
+                      required:
+                      - day
+                      - start1
+                      - end1
+                      - start2
+                      - end2
+                      - notes
+                      additionalProperties: false
+                required:
+                - address
+                - membershipNumber
+                - name
+                - serialNumber
+                - inVCC
+                - isBureau
+                - isOutlet
+                - features
+                - notes
+                - openingTimes
+                - publicContacts
+                - telephoneTimes
+                additionalProperties: false
+        '404':
+          description: when no office with that serial number is found
   "/api/v0/json/location/list":
     get:
       summary: List members

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -424,8 +424,11 @@ paths:
                       properties:
                         id:
                           type: string
+                        name:
+                          type: string
                       required:
                       - id
+                      - name
                       additionalProperties: false
                 required:
                 - match_type


### PR DESCRIPTION
This adds another API that's backwards compatible with Episerver, for fetching an individual office. Initially we believed this wasn't needed for volunteer search, but it does appear to be.