### PR TITLE
Expose office relationships in API

### DIFF
--- a/spec/requests/v1/schema.rb
+++ b/spec/requests/v1/schema.rb
@@ -13,4 +13,88 @@ module ApiV1Schema
     required: [:type],
     additionalProperties: false
   }.freeze
+
+  NULLABLE_STRING = %i[string null].freeze
+
+  GEO_JSON_POINT = {
+    "$id": "https://geojson.org/schema/Point.json",
+    type: :object,
+    properties: {
+      type: { type: :string, enum: ["Point"] },
+      coordinates: { type: :array, items: { type: :number }, minItems: 2, maxItems: 2 }
+    },
+    required: %w[type coordinates],
+    additionalProperties: false
+  }.freeze
+
+  TIME_OF_DAY = {
+    type: :string,
+    pattern: '^\d{2}:\d{2}:\d{2}$'
+  }.freeze
+
+  TIME_RANGE = {
+    type: :object,
+    properties: { opens: TIME_OF_DAY, closes: TIME_OF_DAY },
+    required: %w[opens closes],
+    additionalProperties: false
+  }.freeze
+
+  NULLABLE_TIME_RANGE = [:null, TIME_RANGE].freeze
+
+  OPENING_HOURS = {
+    type: :object,
+    properties: {
+      information: { type: NULLABLE_STRING },
+      monday: { type: NULLABLE_TIME_RANGE },
+      tuesday: { type: NULLABLE_TIME_RANGE },
+      wednesday: { type: NULLABLE_TIME_RANGE },
+      thursday: { type: NULLABLE_TIME_RANGE },
+      friday: { type: NULLABLE_TIME_RANGE },
+      saturday: { type: NULLABLE_TIME_RANGE },
+      sunday: { type: NULLABLE_TIME_RANGE }
+    },
+    required: %w[information monday tuesday wednesday thursday friday saturday sunday],
+    additionalProperties: false
+  }.freeze
+
+  OFFICE_TYPE = { type: :string, enum: %w[member office outreach] }.freeze
+
+  RELATED_OBJECT = {
+    type: :object,
+    properties: {
+      id: { type: :string },
+      type: OFFICE_TYPE,
+      name: { type: :string }
+    },
+    requires: %i[id type name],
+    additionalProperties: false
+  }.freeze
+
+  OFFICE = {
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "https://local-office-search.citizensadvice.org.uk/schemas/v1/office",
+    type: :object,
+    properties: {
+      id: { type: :string },
+      type: OFFICE_TYPE,
+      name: { type: :string },
+      about_text: { type: NULLABLE_STRING },
+      accessibility_information: { type: :array, items: { type: :string } },
+      street: { type: NULLABLE_STRING },
+      city: { type: NULLABLE_STRING },
+      county: { type: NULLABLE_STRING },
+      postcode: { type: NULLABLE_STRING },
+      location: { type: [:null, GEO_JSON_POINT] },
+      email: { type: NULLABLE_STRING },
+      website: { type: NULLABLE_STRING },
+      phone: { type: NULLABLE_STRING },
+      allows_drop_ins: { type: :boolean },
+      opening_hours: OPENING_HOURS,
+      telephone_advice_hours: OPENING_HOURS,
+      relations: { type: :array, items: RELATED_OBJECT }
+    },
+    required: %i[id name about_text accessibility_information street city postcode location email website phone
+                 allows_drop_ins opening_hours telephone_advice_hours relations],
+    additionalProperties: false
+  }.freeze
 end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -31,10 +31,12 @@ paths:
                 properties:
                   id:
                     type: string
-                  member_id:
-                    type:
-                    - string
-                    - 'null'
+                  type:
+                    type: string
+                    enum:
+                    - member
+                    - office
+                    - outreach
                   name:
                     type: string
                   about_text:
@@ -93,6 +95,8 @@ paths:
                     type:
                     - string
                     - 'null'
+                  allows_drop_ins:
+                    type: boolean
                   opening_hours:
                     type: object
                     properties:
@@ -337,9 +341,28 @@ paths:
                     - saturday
                     - sunday
                     additionalProperties: false
+                  relations:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        type:
+                          type: string
+                          enum:
+                          - member
+                          - office
+                          - outreach
+                        name:
+                          type: string
+                      requires:
+                      - id
+                      - type
+                      - name
+                      additionalProperties: false
                 required:
                 - id
-                - member_id
                 - name
                 - about_text
                 - accessibility_information
@@ -350,8 +373,10 @@ paths:
                 - email
                 - website
                 - phone
+                - allows_drop_ins
                 - opening_hours
                 - telephone_advice_hours
+                - relations
                 additionalProperties: false
         '302':
           description: Allows you to look up an office by its resource directory ID


### PR DESCRIPTION
This is to give the frontend the necessary information to navigate through the hierarchy of local offices