### PR TITLE
NAT-210: expose contact methods on search results API

### DIFF
--- a/app/controllers/api/v1/office_controller.rb
+++ b/app/controllers/api/v1/office_controller.rb
@@ -38,7 +38,7 @@ module Api
       rescue OfficeSearch::OutOfAreaError => e
         { match_type: "out_of_area_#{e.country}", results: [] }
       else
-        { match_type: normalised_location.nil? ? "fuzzy" : "exact", results: offices.map { |office| { id: office.id, name: office.name } } }
+        { match_type: normalised_location.nil? ? "fuzzy" : "exact", results: offices.map(&:as_search_result_json) }
       end
 
       def fetch_and_render_office

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -54,6 +54,14 @@ class Office < ApplicationRecord
   end
   # rubocop:enable Metrics/AbcSize
 
+  def as_search_result_json
+    {
+      id:,
+      name:,
+      contact_methods:
+    }
+  end
+
   def as_relation_json
     {
       id:,
@@ -77,5 +85,13 @@ class Office < ApplicationRecord
     return nil if opening_hours.nil?
 
     { opens: opening_hours.beginning.strftime("%H:%M:%S"), closes: opening_hours.ending.strftime("%H:%M:%S") }
+  end
+
+  def contact_methods
+    methods = []
+    methods << "drop_in" if allows_drop_ins
+    methods << "phone" unless phone.nil?
+    methods << "email" unless email.nil?
+    methods
   end
 end

--- a/docs/architecture/decisions/0006-use-simple-matching-for-office-search.md
+++ b/docs/architecture/decisions/0006-use-simple-matching-for-office-search.md
@@ -1,0 +1,39 @@
+# 6. Use simple matching for office search
+
+Date: 2023-08-17
+
+## Status
+
+Accepted
+
+## Context
+
+User research has discovered that users who search for a local Citizens Advice do so because they want
+to find one which can help them. As such, postcode search is preferred as postcode search will only
+show local offices in the same local authority as the entered postcode, and therefore which ones can help
+you.
+
+Existing usage data shows 80% of current users search using postcodes, the remaining 20% use place names.
+Of that 20%, a further 80% of the freetext search strings that were used will match against the name of
+a local office.
+
+Integration of a full geolocation API and design impact of that is only necessary to deal with the long 
+tail of searches. A design hypothesis is that users will try again with a different term or use a
+postcode, which suggests that the work required to integrate this will deliver a low return for the
+initial and ongoing maintenance effort of such a third-party integration.
+
+## Decision
+
+Place name search will be a simple text-matching search against office names and local authority names.
+
+Search results will only show the information necessary to allow a user to select the local
+office that is the best way in for them, rather than return full office objects.
+
+## Consequences
+
+The search results API is heavily tied to the front-end behaviour of Find Your Local Citizens Advice,
+and it has not been engineered to be a more general API - but this decision may be revisited later if
+concrete further use cases are identified.
+
+The search results API will also behave differently than the Local Service Search API when entering a
+place name, as it uses a naive algorithm for search.

--- a/spec/requests/v1/schema.rb
+++ b/spec/requests/v1/schema.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/ModuleLength
+
 module ApiV1Schema
   JSON_PROBLEM = {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
@@ -97,4 +99,38 @@ module ApiV1Schema
                  allows_drop_ins opening_hours telephone_advice_hours relations],
     additionalProperties: false
   }.freeze
+
+  SEARCH_RESULT = {
+    type: :object,
+    properties: {
+      id: { type: :string },
+      name: { type: :string },
+      contact_methods: { type: :array, items: { type: :string, enum: %w[phone email drop_in] } }
+    },
+    required: %i[id name contact_methods],
+    additionalProperties: false
+  }.freeze
+
+  SEARCH_RESULTS = {
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "https://local-office-search.citizensadvice.org.uk/schemas/v1/results",
+    type: :object,
+    properties: {
+      match_type: { type: :string, enum: %w[exact fuzzy unknown out_of_area_scotland out_of_area_ni],
+                    description: %(
+                                * `exact` means the search term matched an exact location, so only offices which serve the exact location
+                                   are shown (this could include no locations).
+                                * `fuzzy` means the search term matched a wider locality and not an individual point, so the results may
+                                   include offices which can not serve that exact location.
+                                * `unknown` means the search term was unable to be interpreted or matched to a location
+                                  (so there are no results).
+                                * `out_of_area_scotland` and `out_of_area_ni` means the search term matched exactly, but to a location in
+                                  Scotland or Northern Ireland which is not in the network coverage area.
+                                ) },
+      results: { type: :array, items: SEARCH_RESULT }
+    },
+    required: %i[match_type results],
+    additionalProperties: false
+  }.freeze
 end
+# rubocop:enable Metrics/ModuleLength

--- a/spec/requests/v1/search_spec.rb
+++ b/spec/requests/v1/search_spec.rb
@@ -10,36 +10,7 @@ RSpec.describe "Search Local Office API" do
       parameter name: :q, in: :query, type: :string, required: true, description: "the search terms to use"
 
       response "200", "a list of search results" do
-        schema "$schema": "https://json-schema.org/draft/2019-09/schema",
-               "$id": "https://local-office-search.citizensadvice.org.uk/schemas/v1/results",
-               type: :object,
-               properties: {
-                 match_type: { type: :string, enum: %w[exact fuzzy unknown out_of_area_scotland out_of_area_ni],
-                               description: %(
-                                * `exact` means the search term matched an exact location, so only offices which serve the exact location
-                                   are shown (this could include no locations).
-                                * `fuzzy` means the search term matched a wider locality and not an individual point, so the results may
-                                   include offices which can not serve that exact location.
-                                * `unknown` means the search term was unable to be interpreted or matched to a location
-                                  (so there are no results).
-                                * `out_of_area_scotland` and `out_of_area_ni` means the search term matched exactly, but to a location in
-                                  Scotland or Northern Ireland which is not in the network coverage area.
-                                ) },
-                 results: {
-                   type: :array,
-                   items: {
-                     type: :object,
-                     properties: {
-                       id: { type: :string },
-                       name: { type: :string }
-                     },
-                     required: %i[id name],
-                     additionalProperties: false
-                   }
-                 }
-               },
-               required: %i[match_type results],
-               additionalProperties: false
+        schema ApiV1Schema::SEARCH_RESULTS
 
         context "when the location is known, but there is no LCA in that area" do
           let(:local_authority_id) { LocalAuthority.create!(id: "X0001234", name: "Testshire").id }
@@ -71,6 +42,48 @@ RSpec.describe "Search Local Office API" do
 
           run_test! do |response|
             expect_result_ids_in_response response, "exact", [office.id]
+          end
+
+          context "with the LCA allowing drop-ins" do
+            let(:office) do
+              Office.new id: generate_salesforce_id,
+                         office_type: :office,
+                         name: "Testshire Citizens Advice",
+                         local_authority_id:,
+                         allows_drop_ins: true
+            end
+
+            run_test! do |response|
+              expect_contact_methods_to_match response, ["drop_in"]
+            end
+          end
+
+          context "with the LCA contactable by phone" do
+            let(:office) do
+              Office.new id: generate_salesforce_id,
+                         office_type: :office,
+                         name: "Testshire Citizens Advice",
+                         local_authority_id:,
+                         phone: "01234 567890"
+            end
+
+            run_test! do |response|
+              expect_contact_methods_to_match response, ["phone"]
+            end
+          end
+
+          context "with the LCA having an email address" do
+            let(:office) do
+              Office.new id: generate_salesforce_id,
+                         office_type: :office,
+                         name: "Testshire Citizens Advice",
+                         local_authority_id:,
+                         email: "cab@example.com"
+            end
+
+            run_test! do |response|
+              expect_contact_methods_to_match response, ["email"]
+            end
           end
         end
 
@@ -140,5 +153,11 @@ RSpec.describe "Search Local Office API" do
 
     expect(body[:match_type]).to eq match_type
     expect(body[:results].pluck(:id)).to eq ids
+  end
+
+  def expect_contact_methods_to_match(response, expected)
+    body = JSON.parse(response.body).deep_symbolize_keys
+
+    expect(body[:results][0][:contact_methods]).to eq(expected)
   end
 end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -451,9 +451,18 @@ paths:
                           type: string
                         name:
                           type: string
+                        contact_methods:
+                          type: array
+                          items:
+                            type: string
+                            enum:
+                            - phone
+                            - email
+                            - drop_in
                       required:
                       - id
                       - name
+                      - contact_methods
                       additionalProperties: false
                 required:
                 - match_type


### PR DESCRIPTION
This adds fields required for the Find Your Local Citizens Advice front-end to display on the results page, and adds an ADR documenting the design decisions made for the search API