### PR TITLE
NAT-547: fix bug serialising offices with no location for EpiServer

### DIFF
--- a/app/controllers/api/v0/serialisers.rb
+++ b/app/controllers/api/v0/serialisers.rb
@@ -88,7 +88,7 @@ module Api
           town: office.city,
           county: office.county,
           postcode: office.postcode,
-          latLong: [office.location.y, office.location.x]
+          latLong: office.location.nil? ? [0.0, 0.0] : [office.location.y, office.location.x]
         }
         if include_local_authority
           block.update({

--- a/spec/requests/v0/member_spec.rb
+++ b/spec/requests/v0/member_spec.rb
@@ -313,6 +313,17 @@ RSpec.describe "Bureau Details legacy API - Members", swagger_doc: "v0/swagger.y
           })
         end
         # rubocop:enable RSpec/ExampleLength
+
+        context "when the location is null" do
+          before do
+            member.update! location: nil
+          end
+
+          run_test! do |response|
+            body = JSON.parse(response.body, symbolize_names: true)
+            expect(body[:address][:latLong]).to eq [0.0, 0.0]
+          end
+        end
       end
 
       response "404", "when no member with that ID is found" do


### PR DESCRIPTION
EpiServer requires a latLong on every office, but this is optional in LSS. It appears Resource Directory handled this by defaulting to co-ords of 0,0 so we replicate the same functionality. It doesn't really matter anyway as volunteer search doesn't render a map so it's not used, but it's a case we need to handle in EpiServer's parsing logic.