### PR TITLE
Revert "NAT-588: use Salesforce hierarchy, not member member, for Episerver lookup"

### DIFF
--- a/app/controllers/api/v0/serialisers.rb
+++ b/app/controllers/api/v0/serialisers.rb
@@ -8,9 +8,9 @@ module Api
 
       # rubocop:disable Metrics/AbcSize
       def member_as_v0_json(member)
-        offices = Office.where(parent_id: member.id, office_type: :office)
+        offices = Office.where(membership_number: params[:id], office_type: :office)
         offices_with_vacancies = offices.reject { |office| office.volunteer_roles.empty? }
-        outreaches = Office.where(parent_id: offices.collect(&:id), office_type: :outreach)
+        outreaches = Office.where(membership_number: params[:id], office_type: :outreach)
 
         {
           address: address_block(member, include_local_authority: true),

--- a/spec/requests/v0/member_spec.rb
+++ b/spec/requests/v0/member_spec.rb
@@ -324,24 +324,6 @@ RSpec.describe "Bureau Details legacy API - Members", swagger_doc: "v0/swagger.y
             expect(body[:address][:latLong]).to eq [0.0, 0.0]
           end
         end
-
-        context "when the outlet is associated using salesforce IDs, not membership number" do
-          let(:outlet) do
-            Office.new(id: generate_salesforce_id,
-                       parent: office,
-                       membership_number: "66/6666",
-                       name: "Felpersham hospital",
-                       street: "North Beck Street",
-                       city: "Felpersham",
-                       office_type: :outreach,
-                       local_authority:)
-          end
-
-          run_test! do |response|
-            body = JSON.parse(response.body, symbolize_names: true)
-            expect(body[:services][:outlets].count).to eq 1
-          end
-        end
       end
 
       response "404", "when no member with that ID is found" do


### PR DESCRIPTION
Reverts citizensadvice/local-office-search-api#77

This introduced another issue due to trying to fit Salesforce's dataset into the Resource Directory model that Episerver's local minisites are still using, so we've made a decision to revert this change and approach the fix in the upstream data by making sure for the minisites we maintain member number in LSS's data.