### PR TITLE
reimplement member list API which is needed for Episerver

### DIFF
--- a/app/controllers/api/v0/member_controller.rb
+++ b/app/controllers/api/v0/member_controller.rb
@@ -13,7 +13,7 @@ module Api
       end
 
       def list
-        head :not_implemented
+        render json: { type: "member", list: Office.where(office_type: :member).map { |office| member_as_v0_list_json(office) } }
       end
     end
   end

--- a/app/controllers/api/v0/serialisers.rb
+++ b/app/controllers/api/v0/serialisers.rb
@@ -30,6 +30,15 @@ module Api
         }
       end
 
+      def member_as_v0_list_json(member)
+        {
+          address: address_block(member, include_local_authority: true),
+          membershipNumber: member.membership_number,
+          name: member.name,
+          serialNumber: member.legacy_id.to_s
+        }
+      end
+
       def location_as_v0_json(office)
         {
           address: address_block(office, include_local_authority: true),

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -5,7 +5,7 @@ Rswag::Api.configure do |c|
   # This is used by the Swagger middleware to serve requests for API descriptions
   # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
   # that it's configured to generate files in the same folder
-  c.swagger_root = Rails.root.join("swagger").to_s
+  c.openapi_root = Rails.root.join("swagger").to_s
 
   # Inject a lambda function to alter the returned Swagger prior to serialization
   # The function will have access to the rack env for the current request

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -9,8 +9,8 @@ Rswag::Ui.configure do |c|
   # (under swagger_root) as JSON or YAML endpoints, then the list below should
   # correspond to the relative paths for those endpoints.
 
-  c.swagger_endpoint "/api-docs/v1/swagger.yaml", "Local Office Search API (v1)"
-  c.swagger_endpoint "/api-docs/v0/swagger.yaml", "Bureau Details API (v0, legacy)"
+  c.openapi_endpoint "/api-docs/v1/swagger.yaml", "Local Office Search API (v1)"
+  c.openapi_endpoint "/api-docs/v0/swagger.yaml", "Bureau Details API (v0, legacy)"
 
   # Add Basic Auth in case your API is private
   # c.basic_auth_enabled = true

--- a/spec/requests/v0/member_spec.rb
+++ b/spec/requests/v0/member_spec.rb
@@ -356,8 +356,54 @@ RSpec.describe "Bureau Details legacy API - Members", swagger_doc: "v0/swagger.y
                   members to the parameter will be returned.
                 DESCRIPTION
 
-      response "501", "is a deprecated API which has not been reimplemented" do
-        run_test!
+      response "200", "returns all the members it knows about" do
+        schema type: :object,
+               properties: {
+                 type: { type: :string, enum: %w[member] },
+                 list: { type: :array, items: BureauDetailsSchema::MEMBER_LIST_SCHEMA }
+               },
+               required: %w[type list],
+               additionalProperties: false
+
+        let(:local_authority) { LocalAuthority.create! id: "E05XXTEST", name: "Borsetshire" }
+
+        let(:member) do
+          Office.new(id: generate_salesforce_id,
+                     legacy_id: 1,
+                     membership_number: "55/5555",
+                     office_type: :member,
+                     name: "Citizens Advice Felpersham",
+                     company_number: "12345678",
+                     charity_number: "87654321",
+                     street: "14 Shakespeare Road",
+                     city: "Felpersham",
+                     postcode: "FX1 7QW",
+                     location: "POINT(-0.7646468 52.0451619)",
+                     local_authority:)
+        end
+
+        before do
+          member.save!
+        end
+
+        # rubocop:disable RSpec/ExampleLength
+        run_test! do |response|
+          expect(JSON.parse(response.body, symbolize_names: true)[:list]).to eq([{
+            address: {
+              address: "14 Shakespeare Road",
+              town: "Felpersham",
+              county: nil,
+              postcode: "FX1 7QW",
+              onsDistrictCode: "E05XXTEST",
+              localAuthority: "Borsetshire",
+              latLong: [52.0451619, -0.7646468]
+            },
+            membershipNumber: "55/5555",
+            name: "Citizens Advice Felpersham",
+            serialNumber: "1"
+          }])
+        end
+        # rubocop:enable RSpec/ExampleLength
       end
     end
   end

--- a/spec/requests/v0/schema.rb
+++ b/spec/requests/v0/schema.rb
@@ -136,5 +136,17 @@ module BureauDetailsSchema
     required: %w[address membershipNumber name serialNumber charityNumber notes services staff vacancies website],
     additionalProperties: false
   }.freeze
+
+  MEMBER_LIST_SCHEMA = {
+    type: :object,
+    properties: {
+      serialNumber: { type: :string },
+      name: { type: :string },
+      membershipNumber: { type: :string },
+      address: ADDRESS_WITH_LOCAL_AUTHORITY_SCHEMA
+    },
+    required: %w[address membershipNumber name serialNumber],
+    additionalProperties: false
+  }.freeze
 end
 # rubocop:enable Metrics/ModuleLength

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -6,12 +6,12 @@ RSpec.configure do |config|
   # Specify a root folder where Swagger JSON files are generated
   # NOTE: If you're using the rswag-api to serve API descriptions, you'll need
   # to ensure that it's configured to serve Swagger from the same folder
-  config.swagger_root = Rails.root.join("swagger").to_s
+  config.openapi_root = Rails.root.join("swagger").to_s
 
   # By default, if response body contains undocumented properties tests will pass.
   # To keep your responses clean and validate against a strict schema definition
   # you can set the global config option:
-  config.swagger_strict_schema_validation = true
+  config.openapi_strict_schema_validation = true
 
   # Define one or more Swagger documents and provide global metadata for each one
   # When you run the 'rswag:specs:swaggerize' rake task, the complete Swagger will
@@ -19,7 +19,7 @@ RSpec.configure do |config|
   # By default, the operations defined in spec files are added to the first
   # document below. You can override this behavior by adding a swagger_doc tag to the
   # the root example_group in your specs, e.g. describe '...', swagger_doc: 'v2/swagger.json'
-  config.swagger_docs = {
+  config.openapi_specs = {
     "v1/swagger.yaml" => {
       openapi: "3.0.1",
       info: {
@@ -70,5 +70,5 @@ RSpec.configure do |config|
   # The swagger_docs configuration option has the filename including format in
   # the key, this may want to be changed to avoid putting yaml in json files.
   # Defaults to json. Accepts ':json' and ':yaml'.
-  config.swagger_format = :yaml
+  config.openapi_format = :yaml
 end

--- a/swagger/v0/swagger.yaml
+++ b/swagger/v0/swagger.yaml
@@ -961,8 +961,72 @@ paths:
         schema:
           type: string
       responses:
-        '501':
-          description: is a deprecated API which has not been reimplemented
+        '200':
+          description: returns all the members it knows about
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    enum:
+                    - member
+                  list:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        serialNumber:
+                          type: string
+                        name:
+                          type: string
+                        membershipNumber:
+                          type: string
+                        address:
+                          type: object
+                          properties:
+                            onsDistrictCode:
+                              type: string
+                            localAuthority:
+                              type: string
+                            address:
+                              type: string
+                            town:
+                              type: string
+                            county:
+                              type:
+                              - string
+                              - 'null'
+                            postcode:
+                              type:
+                              - string
+                              - 'null'
+                            latLong:
+                              type: array
+                              items:
+                                type: number
+                              minItems: 2
+                              maxItems: 2
+                          required:
+                          - address
+                          - town
+                          - county
+                          - postcode
+                          - latLong
+                          - onsDistrictCode
+                          - localAuthority
+                          additionalProperties: false
+                      required:
+                      - address
+                      - membershipNumber
+                      - name
+                      - serialNumber
+                      additionalProperties: false
+                required:
+                - type
+                - list
+                additionalProperties: false
   "/api/v0/json/vacancy/id/{id}":
     get:
       summary: Shows full details for a vacancy


### PR DESCRIPTION
This API is used by the rarely used "Manage member sites" function within Episerver, which was not identified in the initial build, but has now been identified as broken functionality.