### PR TITLE
NAT-888: add many-to-many relationship between LCAs and local authorities

### DIFF
--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -3,4 +3,5 @@
 class LocalAuthority < ApplicationRecord
   has_many :postcodes, dependent: nil
   has_many :offices, dependent: nil
+  has_many :served_areas, dependent: :destroy
 end

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -7,6 +7,7 @@ class Office < ApplicationRecord
   has_many :children, class_name: "Office", foreign_key: "parent_id", dependent: :nullify, inverse_of: :parent
 
   belongs_to :local_authority, optional: true
+  has_many :served_areas, dependent: :destroy
 
   has_many :opening_times, class_name: "OpeningTimes", dependent: :destroy
 

--- a/app/models/served_area.rb
+++ b/app/models/served_area.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class ServedArea < ApplicationRecord
+  belongs_to :office
+  belongs_to :local_authority
+end

--- a/db/migrate/20240813152802_create_served_areas_table.rb
+++ b/db/migrate/20240813152802_create_served_areas_table.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateServedAreasTable < ActiveRecord::Migration[7.1]
+  def change
+    # rubocop:disable Rails/CreateTableWithTimestamps
+    create_table :served_areas do |t|
+      t.references :office, null: false, foreign_key: true, type: "char(18)"
+      t.references :local_authority, null: false, index: true, type: "char(9)"
+    end
+    add_foreign_key :served_areas, :local_authorities, deferrable: true
+    # rubocop:enable Rails/CreateTableWithTimestamps
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -281,6 +281,36 @@ CREATE TABLE public.schema_migrations (
 
 
 --
+-- Name: served_areas; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.served_areas (
+    id bigint NOT NULL,
+    office_id character(18) NOT NULL,
+    local_authority_id character(9) NOT NULL
+);
+
+
+--
+-- Name: served_areas_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.served_areas_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: served_areas_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.served_areas_id_seq OWNED BY public.served_areas.id;
+
+
+--
 -- Name: opening_times id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -292,6 +322,13 @@ ALTER TABLE ONLY public.opening_times ALTER COLUMN id SET DEFAULT nextval('publi
 --
 
 ALTER TABLE ONLY public.postcodes ALTER COLUMN id SET DEFAULT nextval('public.postcodes_id_seq'::regclass);
+
+
+--
+-- Name: served_areas id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.served_areas ALTER COLUMN id SET DEFAULT nextval('public.served_areas_id_seq'::regclass);
 
 
 --
@@ -340,6 +377,14 @@ ALTER TABLE ONLY public.postcodes
 
 ALTER TABLE ONLY public.schema_migrations
     ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
+
+
+--
+-- Name: served_areas served_areas_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.served_areas
+    ADD CONSTRAINT served_areas_pkey PRIMARY KEY (id);
 
 
 --
@@ -392,6 +437,28 @@ CREATE UNIQUE INDEX index_postcodes_on_normalised ON public.postcodes USING btre
 
 
 --
+-- Name: index_served_areas_on_local_authority_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_served_areas_on_local_authority_id ON public.served_areas USING btree (local_authority_id);
+
+
+--
+-- Name: index_served_areas_on_office_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_served_areas_on_office_id ON public.served_areas USING btree (office_id);
+
+
+--
+-- Name: served_areas fk_rails_21c56aa565; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.served_areas
+    ADD CONSTRAINT fk_rails_21c56aa565 FOREIGN KEY (office_id) REFERENCES public.offices(id);
+
+
+--
 -- Name: offices fk_rails_5a2ab5b59d; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -416,6 +483,14 @@ ALTER TABLE ONLY public.postcodes
 
 
 --
+-- Name: served_areas fk_rails_90a03e3955; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.served_areas
+    ADD CONSTRAINT fk_rails_90a03e3955 FOREIGN KEY (local_authority_id) REFERENCES public.local_authorities(id) DEFERRABLE;
+
+
+--
 -- Name: offices fk_rails_b381f08761; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -427,18 +502,18 @@ ALTER TABLE ONLY public.offices
 -- PostgreSQL database dump complete
 --
 
-SET search_path TO "$user", public, topology;
+SET search_path TO "$user", public, topology, tiger;
 
 INSERT INTO "schema_migrations" (version) VALUES
-('20230531135320'),
-('20230621151704'),
-('20230704120347'),
-('20230705095742'),
-('20230705132647'),
-('20230731104744'),
-('20230803141746'),
-('20230803145002'),
+('20240813152802'),
+('20231120143230'),
 ('20231120111349'),
-('20231120143230');
-
+('20230803145002'),
+('20230803141746'),
+('20230731104744'),
+('20230705132647'),
+('20230705095742'),
+('20230704120347'),
+('20230621151704'),
+('20230531135320');
 

--- a/lib/lss_loader.rb
+++ b/lib/lss_loader.rb
@@ -9,18 +9,15 @@ require "lss_loader/validators"
 
 module LssLoader
   class LssLoader
-    include CsvHelpers
     include LoaderHelpers
-    include OfficeBuilder
-    include OpeningTimeBuilder
     include Validators
 
     def initialize(members_csv:, advice_locations_csv:, opening_hours_csv:, volunteer_roles_csv:, accessibility_info_csv:)
-      @members_csv = CSV.new members_csv, headers: true, return_headers: true
-      @advice_locations_csv = CSV.new advice_locations_csv, headers: true, return_headers: true
-      @opening_hours_csv = CSV.new opening_hours_csv, headers: true, return_headers: true
-      @volunteer_roles_csv = CSV.new volunteer_roles_csv, headers: true, return_headers: true
-      @accessibility_info_csv = CSV.new accessibility_info_csv, headers: true, return_headers: true
+      @members_csv = CSV.new(members_csv, headers: true, return_headers: true)
+      @advice_locations_csv = CSV.new(advice_locations_csv, headers: true, return_headers: true)
+      @opening_hours_csv = CSV.new(opening_hours_csv, headers: true, return_headers: true)
+      @volunteer_roles_csv = CSV.new(volunteer_roles_csv, headers: true, return_headers: true)
+      @accessibility_info_csv = CSV.new(accessibility_info_csv, headers: true, return_headers: true)
       initialise_csv_headers!
     end
 
@@ -30,87 +27,23 @@ module LssLoader
         validate_csv_headers!
         clear_existing_records!
 
-        office_map = build_office_and_served_area_records
-        opening_times = build_opening_times(office_map)
+        offices, served_areas = OfficeBuilder.new(@members_csv, @advice_locations_csv, @accessibility_info_csv, @volunteer_roles_csv).build
+        opening_times = OpeningTimeBuilder.new(@opening_hours_csv, offices.map(&:id)).build
 
-        save_offices_and_saved_areas(office_map.values)
+        offices.map(&:save!)
+        served_areas.map(&:save!)
         opening_times.map(&:save!)
       end
     end
 
     private
 
-    def build_office_and_served_area_records
-      offices = {}
-      build_office_records_from_members_csv(offices)
-      build_office_records_from_advice_locations_csv(offices)
-      apply_accessibility_info_from_csv(offices)
-      apply_volunteer_roles_from_csv(offices)
-
-      nullify_dangling_parent_ids! offices
-      nullify_dangling_local_authority_ids! offices
-      offices
-    end
-
-    def build_opening_times(offices)
-      @opening_hours_csv.filter_map { |row| build_opening_time_from_row(row, offices) }
-    end
-
-    def build_office_records_from_members_csv(offices)
-      @members_csv.each do |row|
-        office = office_from_member_row row
-        offices[office[:id]] = [office, served_areas_from_member_row(row)]
-      end
-    end
-
-    def build_office_records_from_advice_locations_csv(offices)
-      @advice_locations_csv.each do |row|
-        next if advice_location_row_is_excluded?(row)
-
-        office = office_from_advice_location_row row
-        offices[office[:id]] = [office, served_areas_from_advice_location_row(row)]
-      end
-    end
-
-    def apply_accessibility_info_from_csv(offices)
-      @accessibility_info_csv.each do |row|
-        apply_accessibility_info! offices, row
-      end
-    end
-
-    def apply_volunteer_roles_from_csv(offices)
-      @volunteer_roles_csv.each do |row|
-        apply_volunteer_roles! offices, row
-      end
-    end
-
-    def nullify_dangling_parent_ids!(offices)
-      orphaned_offices = offices.values.select { |(office, _)| !office.parent_id.nil? && !offices.key?(office.parent_id) }
-      orphaned_offices.each do |(office, _)|
-        office.parent_id = nil
-      end
-    end
-
-    def nullify_dangling_local_authority_ids!(offices)
-      local_authority_ids = LocalAuthority.ids.to_set
-      orphaned_offices = offices.values.reject { |(office, _)| local_authority_ids.include? office.local_authority_id }
-      orphaned_offices.each do |(office, _)|
-        office.local_authority_id = nil
-      end
-    end
-
-    def reject_dangling_local_authority_ids(served_areas)
-      local_authority_ids = LocalAuthority.ids.to_set
-      served_areas.select { |served_area| local_authority_ids.include?(served_area.local_authority_id) }
-    end
-
-    def save_offices_and_saved_areas(offices)
-      served_areas = []
-      offices.map do |(office, office_served_areas)|
-        office.save!
-        served_areas.concat(office_served_areas)
-      end
-      reject_dangling_local_authority_ids(served_areas).map(&:save!)
+    def initialise_csv_headers!
+      @members_csv.shift if @members_csv.headers == true
+      @advice_locations_csv.shift if @advice_locations_csv.headers == true
+      @opening_hours_csv.shift if @opening_hours_csv.headers == true
+      @volunteer_roles_csv.shift if @volunteer_roles_csv.headers == true
+      @accessibility_info_csv.shift if @accessibility_info_csv.headers == true
     end
 
     def clear_existing_records!

--- a/lib/lss_loader.rb
+++ b/lib/lss_loader.rb
@@ -28,26 +28,19 @@ module LssLoader
       ActiveRecord::Base.transaction do
         defer_integrity_checks_until_commit!
         validate_csv_headers!
-        OpeningTimes.delete_all
-        Office.delete_all
-        offices = build_office_records
-        opening_times = build_opening_times(offices)
-        offices.values.map(&:save!)
+        clear_existing_records!
+
+        office_map = build_office_and_served_area_records
+        opening_times = build_opening_times(office_map)
+
+        save_offices_and_saved_areas(office_map.values)
         opening_times.map(&:save!)
       end
     end
 
     private
 
-    def initialise_csv_headers!
-      @members_csv.shift if @members_csv.headers == true
-      @advice_locations_csv.shift if @advice_locations_csv.headers == true
-      @opening_hours_csv.shift if @opening_hours_csv.headers == true
-      @volunteer_roles_csv.shift if @volunteer_roles_csv.headers == true
-      @accessibility_info_csv.shift if @accessibility_info_csv.headers == true
-    end
-
-    def build_office_records
+    def build_office_and_served_area_records
       offices = {}
       build_office_records_from_members_csv(offices)
       build_office_records_from_advice_locations_csv(offices)
@@ -66,7 +59,7 @@ module LssLoader
     def build_office_records_from_members_csv(offices)
       @members_csv.each do |row|
         office = office_from_member_row row
-        offices[office[:id]] = office
+        offices[office[:id]] = [office, served_areas_from_member_row(row)]
       end
     end
 
@@ -75,7 +68,7 @@ module LssLoader
         next if advice_location_row_is_excluded?(row)
 
         office = office_from_advice_location_row row
-        offices[office[:id]] = office
+        offices[office[:id]] = [office, served_areas_from_advice_location_row(row)]
       end
     end
 
@@ -92,18 +85,38 @@ module LssLoader
     end
 
     def nullify_dangling_parent_ids!(offices)
-      orphaned_offices = offices.values.select { |office| !office.parent_id.nil? && !offices.key?(office.parent_id) }
-      orphaned_offices.each do |office|
+      orphaned_offices = offices.values.select { |(office, _)| !office.parent_id.nil? && !offices.key?(office.parent_id) }
+      orphaned_offices.each do |(office, _)|
         office.parent_id = nil
       end
     end
 
     def nullify_dangling_local_authority_ids!(offices)
       local_authority_ids = LocalAuthority.ids.to_set
-      orphaned_offices = offices.values.reject { |office| local_authority_ids.include? office.local_authority_id }
-      orphaned_offices.each do |office|
+      orphaned_offices = offices.values.reject { |(office, _)| local_authority_ids.include? office.local_authority_id }
+      orphaned_offices.each do |(office, _)|
         office.local_authority_id = nil
       end
+    end
+
+    def reject_dangling_local_authority_ids(served_areas)
+      local_authority_ids = LocalAuthority.ids.to_set
+      served_areas.select { |served_area| local_authority_ids.include?(served_area.local_authority_id) }
+    end
+
+    def save_offices_and_saved_areas(offices)
+      served_areas = []
+      offices.map do |(office, office_served_areas)|
+        office.save!
+        served_areas.concat(office_served_areas)
+      end
+      reject_dangling_local_authority_ids(served_areas).map(&:save!)
+    end
+
+    def clear_existing_records!
+      ServedArea.delete_all
+      OpeningTimes.delete_all
+      Office.delete_all
     end
 
     def defer_integrity_checks_until_commit!

--- a/lib/lss_loader/office_builder.rb
+++ b/lib/lss_loader/office_builder.rb
@@ -48,6 +48,19 @@ module LssLoader
     end
     # rubocop:enable Metrics/AbcSize
 
+    def served_areas_from_member_row(row)
+      served_areas = []
+      served_areas << ServedArea.new(office_id: row["salesforce_id"], local_authority_id: str_or_nil(row["local_authority_ons_code"]))
+      served_areas.reject { |served_area| served_area.local_authority_id.nil? }
+    end
+
+    def served_areas_from_advice_location_row(row)
+      served_areas = []
+      served_areas << ServedArea.new(office_id: row["salesforce_advice_location_id"],
+                                     local_authority_id: str_or_nil(row["local_authority_ons_code"]))
+      served_areas.reject { |served_area| served_area.local_authority_id.nil? }
+    end
+
     def advice_location_row_is_excluded?(row)
       row["salesforce_advice_location_id"].nil? ||
         bool_from_val(row["excluded_from_lss_front_end"]) ||
@@ -57,13 +70,13 @@ module LssLoader
     def apply_accessibility_info!(offices, row)
       return unless offices.key? row["salesforce_advice_location_id"]
 
-      offices[row["salesforce_advice_location_id"]].accessibility_information << row["advice_location_accessibility"]
+      offices[row["salesforce_advice_location_id"]][0].accessibility_information << row["advice_location_accessibility"]
     end
 
     def apply_volunteer_roles!(offices, row)
       return unless offices.key? row["salesforce_advice_location_id"]
 
-      offices[row["salesforce_advice_location_id"]].volunteer_roles << row["volunteer_roles"]
+      offices[row["salesforce_advice_location_id"]][0].volunteer_roles << row["volunteer_roles"]
     end
 
     def record_type_id_to_office_type(record_type_id)

--- a/lib/lss_loader/office_builder.rb
+++ b/lib/lss_loader/office_builder.rb
@@ -1,82 +1,152 @@
 # frozen_string_literal: true
 
 module LssLoader
-  module OfficeBuilder
-    private
+  class OfficeBuilder
+    include CsvHelpers
 
-    # rubocop:disable Metrics/AbcSize
-    def office_from_member_row(row)
-      Office.new id: row["salesforce_id"],
-                 name: row["member_full_name"],
-                 office_type: record_type_id_to_office_type(row["location_type_id"]),
-                 parent_id: str_or_nil(row["salesforce_parent_id"]),
-                 legacy_id: str_or_nil(row["resource_directory_id"]),
-                 membership_number: str_or_nil(row["membership_number"]),
-                 charity_number: str_or_nil(row["charity_number"]),
-                 company_number: str_or_nil(row["company_number"]),
-                 street: str_or_nil(row["street_name"]),
-                 city: str_or_nil(row["city"]),
-                 county: str_or_nil(row["county"]),
-                 postcode: str_or_nil(row["postcode"]),
-                 location: point_wkt_or_nil(row["latitude"], row["longitude"]),
-                 local_authority_id: str_or_nil(row["local_authority_ons_code"]),
-                 email: str_or_nil(row["enquiries_email"]),
-                 website: str_or_nil(row["public_website"])
+    def initialize(members_csv, advice_locations_csv, accessibility_info_csv, volunteer_roles_csv)
+      @members_csv = members_csv
+      @advice_locations_csv = advice_locations_csv
+      @accessibility_info_csv = accessibility_info_csv
+      @volunteer_roles_csv = volunteer_roles_csv
     end
 
-    def office_from_advice_location_row(row)
-      Office.new id: row["salesforce_advice_location_id"],
-                 name: row["advice_location_name"],
-                 office_type: record_type_id_to_office_type(row["location_type_id"]),
-                 parent_id: str_or_nil(row["salesforce_parent_id"]),
-                 legacy_id: str_or_nil(row["resource_directory_id"]),
-                 membership_number: str_or_nil(row["membership_number"]),
-                 about_text: str_or_nil(row["advice_service_information"]),
-                 street: str_or_nil(row["street_name"]),
-                 city: str_or_nil(row["city"]),
-                 county: str_or_nil(row["county"]),
-                 postcode: str_or_nil(row["postcode"]),
-                 location: point_wkt_or_nil(row["latitude"], row["longitude"]),
-                 local_authority_id: str_or_nil(row["local_authority_ons_code"]),
-                 email: str_or_nil(row["enquiries_email"]),
-                 volunteer_recruitment_email: str_or_nil(row["volunteer_recruitment_email"]),
-                 website: str_or_nil(row["public_website"]),
-                 phone: str_or_nil(row["phone"]),
-                 allows_drop_ins: bool_from_val(row["allows_drop_in_visits"]),
-                 opening_hours_information: str_or_nil(row["face_to_face_advice_hours_information"]),
-                 telephone_advice_hours_information: str_or_nil(row["telephone_advice_hours_information"])
+    def build
+      @offices = {}
+      @served_areas = []
+      @valid_local_authority_ids = LocalAuthority.ids.to_set
+
+      load_members_csv!
+      load_advice_locations_csv!
+      load_accessibility_info_csv!
+      load_volunteer_roles_csv!
+      nullify_dangling_parent_ids!
+      nullify_dangling_local_authority_ids!
+
+      [@offices.values, @served_areas]
+    end
+
+    private
+
+    def load_members_csv!
+      @members_csv.each do |row|
+        build_office_from_member_row(row)
+        build_served_areas_from_member_row(row)
+      end
+    end
+
+    def load_advice_locations_csv!
+      @advice_locations_csv.each do |row|
+        next if advice_location_row_is_excluded?(row)
+
+        build_office_from_advice_location_row(row)
+        build_served_areas_from_advice_location_row(row)
+      end
+    end
+
+    def load_accessibility_info_csv!
+      @accessibility_info_csv.each do |row|
+        apply_accessibility_info_from_row(row)
+      end
+    end
+
+    def load_volunteer_roles_csv!
+      @volunteer_roles_csv.each do |row|
+        apply_volunteer_roles_from_row(row)
+      end
+    end
+
+    # rubocop:disable Metrics/AbcSize
+    def build_office_from_member_row(row)
+      @offices[row["salesforce_id"]] = Office.new(
+        id: row["salesforce_id"],
+        name: row["member_full_name"],
+        office_type: record_type_id_to_office_type(row["location_type_id"]),
+        parent_id: str_or_nil(row["salesforce_parent_id"]),
+        legacy_id: str_or_nil(row["resource_directory_id"]),
+        membership_number: str_or_nil(row["membership_number"]),
+        charity_number: str_or_nil(row["charity_number"]),
+        company_number: str_or_nil(row["company_number"]),
+        street: str_or_nil(row["street_name"]),
+        city: str_or_nil(row["city"]),
+        county: str_or_nil(row["county"]),
+        postcode: str_or_nil(row["postcode"]),
+        location: point_wkt_or_nil(row["latitude"], row["longitude"]),
+        local_authority_id: str_or_nil(row["local_authority_ons_code"]),
+        email: str_or_nil(row["enquiries_email"]),
+        website: str_or_nil(row["public_website"])
+      )
+    end
+
+    def build_office_from_advice_location_row(row)
+      @offices[row["salesforce_advice_location_id"]] = Office.new(
+        id: row["salesforce_advice_location_id"],
+        name: row["advice_location_name"],
+        office_type: record_type_id_to_office_type(row["location_type_id"]),
+        parent_id: str_or_nil(row["salesforce_parent_id"]),
+        legacy_id: str_or_nil(row["resource_directory_id"]),
+        membership_number: str_or_nil(row["membership_number"]),
+        about_text: str_or_nil(row["advice_service_information"]),
+        street: str_or_nil(row["street_name"]),
+        city: str_or_nil(row["city"]),
+        county: str_or_nil(row["county"]),
+        postcode: str_or_nil(row["postcode"]),
+        location: point_wkt_or_nil(row["latitude"], row["longitude"]),
+        local_authority_id: str_or_nil(row["local_authority_ons_code"]),
+        email: str_or_nil(row["enquiries_email"]),
+        volunteer_recruitment_email: str_or_nil(row["volunteer_recruitment_email"]),
+        website: str_or_nil(row["public_website"]),
+        phone: str_or_nil(row["phone"]),
+        allows_drop_ins: bool_from_val(row["allows_drop_in_visits"]),
+        opening_hours_information: str_or_nil(row["face_to_face_advice_hours_information"]),
+        telephone_advice_hours_information: str_or_nil(row["telephone_advice_hours_information"])
+      )
     end
     # rubocop:enable Metrics/AbcSize
 
-    def served_areas_from_member_row(row)
-      served_areas = []
-      served_areas << ServedArea.new(office_id: row["salesforce_id"], local_authority_id: str_or_nil(row["local_authority_ons_code"]))
-      served_areas.reject { |served_area| served_area.local_authority_id.nil? }
+    def build_served_areas_from_member_row(row)
+      ["local_authority_ons_code"].each do |served_area_column|
+        local_authority_id = str_or_nil(row[served_area_column])
+        if @valid_local_authority_ids.include?(local_authority_id)
+          @served_areas << ServedArea.new(office_id: row["salesforce_id"], local_authority_id:)
+        end
+      end
     end
 
-    def served_areas_from_advice_location_row(row)
-      served_areas = []
-      served_areas << ServedArea.new(office_id: row["salesforce_advice_location_id"],
-                                     local_authority_id: str_or_nil(row["local_authority_ons_code"]))
-      served_areas.reject { |served_area| served_area.local_authority_id.nil? }
+    def build_served_areas_from_advice_location_row(row)
+      ["local_authority_ons_code"].each do |served_area_column|
+        local_authority_id = str_or_nil(row[served_area_column])
+        if @valid_local_authority_ids.include?(local_authority_id)
+          @served_areas << ServedArea.new(office_id: row["salesforce_advice_location_id"], local_authority_id:)
+        end
+      end
+    end
+
+    def apply_accessibility_info_from_row(row)
+      return unless @offices.key? row["salesforce_advice_location_id"]
+
+      @offices[row["salesforce_advice_location_id"]].accessibility_information << row["advice_location_accessibility"]
+    end
+
+    def apply_volunteer_roles_from_row(row)
+      return unless @offices.key? row["salesforce_advice_location_id"]
+
+      @offices[row["salesforce_advice_location_id"]].volunteer_roles << row["volunteer_roles"]
+    end
+
+    def nullify_dangling_parent_ids!
+      orphaned_offices = @offices.values.reject { |office| office.parent_id.nil? || @offices.key?(office.parent_id) }
+      orphaned_offices.each { |office| office.parent_id = nil }
+    end
+
+    def nullify_dangling_local_authority_ids!
+      orphaned_offices = @offices.values.reject { |office| @valid_local_authority_ids.include? office.local_authority_id }
+      orphaned_offices.each { |office| office.local_authority_id = nil }
     end
 
     def advice_location_row_is_excluded?(row)
       row["salesforce_advice_location_id"].nil? ||
-        bool_from_val(row["excluded_from_lss_front_end"]) ||
-        bool_from_val(row["excluded_from_lss_reports"])
-    end
-
-    def apply_accessibility_info!(offices, row)
-      return unless offices.key? row["salesforce_advice_location_id"]
-
-      offices[row["salesforce_advice_location_id"]][0].accessibility_information << row["advice_location_accessibility"]
-    end
-
-    def apply_volunteer_roles!(offices, row)
-      return unless offices.key? row["salesforce_advice_location_id"]
-
-      offices[row["salesforce_advice_location_id"]][0].volunteer_roles << row["volunteer_roles"]
+        bool_from_val(row["excluded_from_lss_front_end"]) || bool_from_val(row["excluded_from_lss_reports"])
     end
 
     def record_type_id_to_office_type(record_type_id)

--- a/lib/lss_loader/opening_time_builder.rb
+++ b/lib/lss_loader/opening_time_builder.rb
@@ -1,11 +1,22 @@
 # frozen_string_literal: true
 
 module LssLoader
-  module OpeningTimeBuilder
+  class OpeningTimeBuilder
+    include CsvHelpers
+
+    def initialize(opening_times_csv, valid_offices)
+      @opening_times_csv = opening_times_csv
+      @valid_offices = valid_offices
+    end
+
+    def build
+      @opening_times_csv.filter_map { |row| build_opening_time_from_row(row) }
+    end
+
     private
 
-    def build_opening_time_from_row(row, offices)
-      return unless str_or_nil(row["session_type"]).present? && offices.key?(row["advice_location_salesforce_id"])
+    def build_opening_time_from_row(row)
+      return unless str_or_nil(row["session_type"]).present? && @valid_offices.include?(row["advice_location_salesforce_id"])
 
       range = shift_from_row(row)
 

--- a/lib/lss_loader/validators.rb
+++ b/lib/lss_loader/validators.rb
@@ -2,6 +2,14 @@
 
 module LssLoader
   module Validators
+    def initialise_csv_headers!
+      @members_csv.shift if @members_csv.headers == true
+      @advice_locations_csv.shift if @advice_locations_csv.headers == true
+      @opening_hours_csv.shift if @opening_hours_csv.headers == true
+      @volunteer_roles_csv.shift if @volunteer_roles_csv.headers == true
+      @accessibility_info_csv.shift if @accessibility_info_csv.headers == true
+    end
+
     def validate_csv_headers!
       raise LssLoadError, "Members CSV file was not in expected format" unless members_csv_has_expected_headers?
       raise LssLoadError, "Advice Locations CSV file was not in expected format" unless advice_locations_csv_has_expected_headers?

--- a/lib/lss_loader/validators.rb
+++ b/lib/lss_loader/validators.rb
@@ -2,14 +2,6 @@
 
 module LssLoader
   module Validators
-    def initialise_csv_headers!
-      @members_csv.shift if @members_csv.headers == true
-      @advice_locations_csv.shift if @advice_locations_csv.headers == true
-      @opening_hours_csv.shift if @opening_hours_csv.headers == true
-      @volunteer_roles_csv.shift if @volunteer_roles_csv.headers == true
-      @accessibility_info_csv.shift if @accessibility_info_csv.headers == true
-    end
-
     def validate_csv_headers!
       raise LssLoadError, "Members CSV file was not in expected format" unless members_csv_has_expected_headers?
       raise LssLoadError, "Advice Locations CSV file was not in expected format" unless advice_locations_csv_has_expected_headers?

--- a/lib/postcode_loader.rb
+++ b/lib/postcode_loader.rb
@@ -58,13 +58,16 @@ class PostcodeLoader
   def defer_local_authority_integrity_checks_until_commit!
     postcode_local_authority_foreign_key = "fk_rails_7ab3384eab"
     office_local_authority_foreign_key = "fk_rails_5a2ab5b59d"
+    served_areas_local_authority_foreign_key = "fk_rails_90a03e3955"
     defer_constraint_until_commit! postcode_local_authority_foreign_key
     defer_constraint_until_commit! office_local_authority_foreign_key
+    defer_constraint_until_commit! served_areas_local_authority_foreign_key
   end
 
   def nullify_dangling_offices!(current_local_authority_ids)
     # rubocop:disable Rails/SkipsModelValidations - we rely on database validations
     Office.where.not(local_authority_id: current_local_authority_ids).update_all(local_authority_id: nil)
+    ServedArea.where.not(local_authority_id: current_local_authority_ids).delete_all
     # rubocop:enable Rails/SkipsModelValidations
   end
 

--- a/spec/lss_loader_spec.rb
+++ b/spec/lss_loader_spec.rb
@@ -168,6 +168,13 @@ RSpec.describe LssLoader do
     expect(Office.find("0014K000009EMMbQAO").local_authority_id).to eq("E06000023")
   end
 
+  it "loads in local authority IDs on advice locations into the served areas table" do
+    LocalAuthority.create! id: "E06000023", name: "Bristol, City of"
+    load_from_fixtures locations_csv_filename: "has_local_authority"
+
+    expect(Office.find("0014K000009EMMbQAO").served_areas.first&.local_authority_id).to eq("E06000023")
+  end
+
   # rubocop:disable RSpec/ExampleLength
   it "loads in members from the members file" do
     LocalAuthority.create! id: "E07000112", name: "Folkestone and Hythe"

--- a/spec/lss_loader_spec.rb
+++ b/spec/lss_loader_spec.rb
@@ -175,6 +175,13 @@ RSpec.describe LssLoader do
     expect(Office.find("0014K000009EMMbQAO").served_areas.first&.local_authority_id).to eq("E06000023")
   end
 
+  it "loads in local authority IDs on members into the served areas table" do
+    LocalAuthority.create! id: "E07000112", name: "Folkestone and Hythe"
+    load_from_fixtures members_csv_filename: "minimal"
+
+    expect(Office.find("0014K00000PcC94QAF").served_areas.first&.local_authority_id).to eq("E07000112")
+  end
+
   # rubocop:disable RSpec/ExampleLength
   it "loads in members from the members file" do
     LocalAuthority.create! id: "E07000112", name: "Folkestone and Hythe"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -32,9 +32,6 @@ rescue ActiveRecord::PendingMigrationError => e
   abort e.to_s.strip
 end
 RSpec.configure do |config|
-  # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = Rails.root.join "spec/fixtures"
-
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.


### PR DESCRIPTION
LSS now supports many-to-many relationships between LCAs and local authorities, as some LCAs serve multiple council areas. At the moment we currently tell users there is no LCA in their area if they are not in the primary local authority of that LCA, which is a poor user experience.

Network Data will have to update their data feed to us to expose this data, but in advance of that we can change the relationships between local authorities and local offices to be a many-to-many relationship. This table will be populated on import, and once the new table is deployed to prod and the first import job has run, we can then remove the old belongs_to field on Office and start querying using the new table. Until then, this leaves the old field and old query logic in place so there is no disruption to the end user.