### PR TITLE
NAT-888: use new many-to-many table for looking up LCAs in a served area

### DIFF
--- a/app/controllers/api/v0/serialisers.rb
+++ b/app/controllers/api/v0/serialisers.rb
@@ -91,6 +91,7 @@ module Api
         end
       end
 
+      # rubocop:disable Metrics/AbcSize
       def address_block(office, include_local_authority:)
         block = {
           address: office.street,
@@ -100,15 +101,13 @@ module Api
           latLong: office.location.nil? ? [0.0, 0.0] : [office.location.y, office.location.x]
         }
         if include_local_authority
-          block.update({
-            onsDistrictCode: office.local_authority&.id,
-            localAuthority: office.local_authority&.name
-          })
+          local_authority = office.served_areas.first&.local_authority
+          block.update({ onsDistrictCode: local_authority.id, localAuthority: local_authority.name }) if local_authority.present?
         end
         block
       end
 
-      # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
+      # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength
       def opening_time_block(office, time_type)
         days = %w[Monday Tuesday Wednesday Thursday Friday Saturday Sunday]
         case time_type

--- a/lib/office_search.rb
+++ b/lib/office_search.rb
@@ -49,7 +49,7 @@ module OfficeSearch
   def self.build_query_from_location(location, local_authority_id, opts)
     q = Office.where(office_type: :office)
     q = if opts[:only_in_same_local_authority]
-          q.where(local_authority_id:)
+          q.joins(:served_areas).where(served_areas: { local_authority_id: })
         else
           q.limit(10)
         end
@@ -66,7 +66,7 @@ module OfficeSearch
   end
 
   def self.build_fuzzy_query(near, opts)
-    office_with_local_authorities = Office.left_outer_joins(:local_authority)
+    office_with_local_authorities = Office.left_outer_joins(served_areas: :local_authority)
     q = office_with_local_authorities.where(Office.arel_table[:name].matches("%#{near}%"))
     q = q.or(office_with_local_authorities.where(LocalAuthority.arel_table[:name].matches("%#{near}%")))
     q = q.where(office_type: :office)

--- a/spec/requests/v0/location_spec.rb
+++ b/spec/requests/v0/location_spec.rb
@@ -30,8 +30,7 @@ RSpec.describe "Bureau Details legacy API - Locations", swagger_doc: "v0/swagger
                      street: "14 Shakespeare Road",
                      city: "Felpersham",
                      postcode: "FX1 7QW",
-                     location: "POINT(-0.7646468 52.0451619)",
-                     local_authority:)
+                     location: "POINT(-0.7646468 52.0451619)")
         end
 
         let(:office) do
@@ -52,8 +51,7 @@ RSpec.describe "Bureau Details legacy API - Locations", swagger_doc: "v0/swagger
                      opening_hours_information: "Self help computers 9am to 4pm",
                      email: "felphersham@example.com",
                      website: "http://www.felpershamcab.org.uk",
-                     phone: "01632 555 555",
-                     local_authority:)
+                     phone: "01632 555 555")
         end
 
         let(:serial_number) do
@@ -63,6 +61,9 @@ RSpec.describe "Bureau Details legacy API - Locations", swagger_doc: "v0/swagger
         before do
           member.save
           office.save
+
+          ServedArea.create!(office_id: member.id, local_authority_id: local_authority.id)
+          ServedArea.create!(office_id: office.id, local_authority_id: local_authority.id)
 
           OpeningTimes.create(office_id: office.id, day_of_week: "monday", opening_time_for: "office",
                               range: Tod::Shift.new(Tod::TimeOfDay.new(10), Tod::TimeOfDay.new(12, 30)))

--- a/spec/requests/v0/member_spec.rb
+++ b/spec/requests/v0/member_spec.rb
@@ -33,8 +33,7 @@ RSpec.describe "Bureau Details legacy API - Members", swagger_doc: "v0/swagger.y
                      street: "14 Shakespeare Road",
                      city: "Felpersham",
                      postcode: "FX1 7QW",
-                     location: "POINT(-0.7646468 52.0451619)",
-                     local_authority:)
+                     location: "POINT(-0.7646468 52.0451619)")
         end
 
         let(:office) do
@@ -55,8 +54,7 @@ RSpec.describe "Bureau Details legacy API - Members", swagger_doc: "v0/swagger.y
                      opening_hours_information: "Self help computers 9am to 4pm",
                      email: "felphersham@example.com",
                      website: "http://www.felpershamcab.org.uk",
-                     phone: "01632 555 555",
-                     local_authority:)
+                     phone: "01632 555 555")
         end
 
         let(:outlet) do
@@ -71,8 +69,7 @@ RSpec.describe "Bureau Details legacy API - Members", swagger_doc: "v0/swagger.y
                      membership_number: "55/5555",
                      office_type: :outreach,
                      about_text: "This location does not exist.",
-                     accessibility_information: ["Wheelchair accessible"],
-                     local_authority:)
+                     accessibility_information: ["Wheelchair accessible"])
         end
 
         let(:id) do
@@ -83,6 +80,10 @@ RSpec.describe "Bureau Details legacy API - Members", swagger_doc: "v0/swagger.y
           member.save
           office.save
           outlet.save
+
+          ServedArea.create!(office_id: member.id, local_authority_id: local_authority.id)
+          ServedArea.create!(office_id: office.id, local_authority_id: local_authority.id)
+          ServedArea.create!(office_id: outlet.id, local_authority_id: local_authority.id)
 
           OpeningTimes.create(office_id: office.id, day_of_week: "monday", opening_time_for: "office",
                               range: Tod::Shift.new(Tod::TimeOfDay.new(10), Tod::TimeOfDay.new(12, 30)))
@@ -378,12 +379,12 @@ RSpec.describe "Bureau Details legacy API - Members", swagger_doc: "v0/swagger.y
                      street: "14 Shakespeare Road",
                      city: "Felpersham",
                      postcode: "FX1 7QW",
-                     location: "POINT(-0.7646468 52.0451619)",
-                     local_authority:)
+                     location: "POINT(-0.7646468 52.0451619)")
         end
 
         before do
           member.save!
+          ServedArea.create!(office_id: member.id, local_authority_id: local_authority.id)
         end
 
         # rubocop:disable RSpec/ExampleLength

--- a/spec/requests/v0/vacancy_spec.rb
+++ b/spec/requests/v0/vacancy_spec.rb
@@ -30,8 +30,10 @@ RSpec.describe "Bureau Details legacy API - Vacancies", swagger_doc: "v0/swagger
                                   email: "felphersham@example.com",
                                   website: "http://www.felpershamcab.org.uk",
                                   phone: "01632 555 555",
-                                  volunteer_roles: %w[admin_and_customer_service volunteer_recruitment_and_support],
-                                  local_authority:)
+                                  volunteer_roles: %w[admin_and_customer_service volunteer_recruitment_and_support])
+
+          ServedArea.create!(office:, local_authority:)
+
           office.id
         end
 
@@ -130,8 +132,10 @@ RSpec.describe "Bureau Details legacy API - Vacancies", swagger_doc: "v0/swagger
                                   email: "felphersham@example.com",
                                   website: "http://www.felpershamcab.org.uk",
                                   phone: "01632 555 555",
-                                  volunteer_roles: ["Receptionist", "Volunteer recruitment and support"],
-                                  local_authority:)
+                                  volunteer_roles: ["Receptionist", "Volunteer recruitment and support"])
+
+          ServedArea.create!(office:, local_authority:)
+
           office.id
         end
 

--- a/spec/requests/v2/search_spec.rb
+++ b/spec/requests/v2/search_spec.rb
@@ -34,11 +34,13 @@ RSpec.describe "Search Local Office API" do
           let(:office) do
             Office.new id: generate_salesforce_id,
                        office_type: :office,
-                       name: "Testshire Citizens Advice",
-                       local_authority_id:
+                       name: "Testshire Citizens Advice"
           end
 
-          before { office.save! }
+          before do
+            office.save!
+            ServedArea.create!(local_authority_id:, office:)
+          end
 
           run_test! do |response|
             expect_result_ids_in_response response, "exact", [office.id]
@@ -49,7 +51,6 @@ RSpec.describe "Search Local Office API" do
               Office.new id: generate_salesforce_id,
                          office_type: :office,
                          name: "Testshire Citizens Advice",
-                         local_authority_id:,
                          allows_drop_ins: true
             end
 
@@ -63,7 +64,6 @@ RSpec.describe "Search Local Office API" do
               Office.new id: generate_salesforce_id,
                          office_type: :office,
                          name: "Testshire Citizens Advice",
-                         local_authority_id:,
                          phone: "01234 567890"
             end
 
@@ -77,7 +77,6 @@ RSpec.describe "Search Local Office API" do
               Office.new id: generate_salesforce_id,
                          office_type: :office,
                          name: "Testshire Citizens Advice",
-                         local_authority_id:,
                          email: "cab@example.com"
             end
 
@@ -118,8 +117,7 @@ RSpec.describe "Search Local Office API" do
           let(:office) do
             Office.new id: generate_salesforce_id,
                        office_type: :office,
-                       name: "Testshire Citizens Advice",
-                       local_authority_id:
+                       name: "Testshire Citizens Advice"
           end
 
           before { office.save! }


### PR DESCRIPTION
This is another step on the journey for supporting an office serving multiple local authority areas. A [previous PR](https://github.com/citizensadvice/local-office-search-api/pull/167) added this table and updated the importer to populate it, now that is deployed and the importer has run in prod so this table is populated, we can switch from the old `local_authority_id` attribute on a model to using the new many-to-many table for searches.

A future PR will stop the old attribute being set, and then remove that from the table completely.