### PR TITLE
NAT-888: remove legacy local authority column on office

### DIFF
--- a/db/migrate/20240904130334_remove_office_local_authority_id.rb
+++ b/db/migrate/20240904130334_remove_office_local_authority_id.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveOfficeLocalAuthorityId < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :offices, :local_authority_id, index: true, type: "char(9)", null: false, references: :local_authority
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -199,7 +199,6 @@ CREATE TABLE public.offices (
     membership_number character varying,
     company_number character varying,
     charity_number character varying,
-    local_authority_id character(9),
     volunteer_roles text[] DEFAULT '{}'::text[] NOT NULL,
     county text,
     volunteer_recruitment_email text,
@@ -395,13 +394,6 @@ CREATE INDEX index_offices_on_legacy_id ON public.offices USING btree (legacy_id
 
 
 --
--- Name: index_offices_on_local_authority_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_offices_on_local_authority_id ON public.offices USING btree (local_authority_id);
-
-
---
 -- Name: index_offices_on_membership_number_and_office_type; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -459,14 +451,6 @@ ALTER TABLE ONLY public.served_areas
 
 
 --
--- Name: offices fk_rails_5a2ab5b59d; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.offices
-    ADD CONSTRAINT fk_rails_5a2ab5b59d FOREIGN KEY (local_authority_id) REFERENCES public.local_authorities(id) DEFERRABLE;
-
-
---
 -- Name: opening_times fk_rails_67a7efc4d6; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -505,6 +489,7 @@ ALTER TABLE ONLY public.offices
 SET search_path TO "$user", public, topology, tiger;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20240904130334'),
 ('20240813152802'),
 ('20231120143230'),
 ('20231120111349'),

--- a/lib/lss_loader.rb
+++ b/lib/lss_loader.rb
@@ -53,9 +53,7 @@ module LssLoader
     end
 
     def defer_integrity_checks_until_commit!
-      office_local_authority_foreign_key = "fk_rails_5a2ab5b59d"
       office_parent_foreign_key = "fk_rails_b381f08761"
-      defer_constraint_until_commit! office_local_authority_foreign_key
       defer_constraint_until_commit! office_parent_foreign_key
     end
   end

--- a/lib/lss_loader/office_builder.rb
+++ b/lib/lss_loader/office_builder.rb
@@ -21,7 +21,6 @@ module LssLoader
       load_accessibility_info_csv!
       load_volunteer_roles_csv!
       nullify_dangling_parent_ids!
-      nullify_dangling_local_authority_ids!
 
       [@offices.values, @served_areas]
     end
@@ -72,7 +71,6 @@ module LssLoader
         county: str_or_nil(row["county"]),
         postcode: str_or_nil(row["postcode"]),
         location: point_wkt_or_nil(row["latitude"], row["longitude"]),
-        local_authority_id: str_or_nil(row["local_authority_ons_code"]),
         email: str_or_nil(row["enquiries_email"]),
         website: str_or_nil(row["public_website"])
       )
@@ -92,7 +90,6 @@ module LssLoader
         county: str_or_nil(row["county"]),
         postcode: str_or_nil(row["postcode"]),
         location: point_wkt_or_nil(row["latitude"], row["longitude"]),
-        local_authority_id: str_or_nil(row["local_authority_ons_code"]),
         email: str_or_nil(row["enquiries_email"]),
         volunteer_recruitment_email: str_or_nil(row["volunteer_recruitment_email"]),
         website: str_or_nil(row["public_website"]),
@@ -137,11 +134,6 @@ module LssLoader
     def nullify_dangling_parent_ids!
       orphaned_offices = @offices.values.reject { |office| office.parent_id.nil? || @offices.key?(office.parent_id) }
       orphaned_offices.each { |office| office.parent_id = nil }
-    end
-
-    def nullify_dangling_local_authority_ids!
-      orphaned_offices = @offices.values.reject { |office| @valid_local_authority_ids.include? office.local_authority_id }
-      orphaned_offices.each { |office| office.local_authority_id = nil }
     end
 
     def advice_location_row_is_excluded?(row)

--- a/lib/postcode_loader.rb
+++ b/lib/postcode_loader.rb
@@ -57,18 +57,14 @@ class PostcodeLoader
 
   def defer_local_authority_integrity_checks_until_commit!
     postcode_local_authority_foreign_key = "fk_rails_7ab3384eab"
-    office_local_authority_foreign_key = "fk_rails_5a2ab5b59d"
     served_areas_local_authority_foreign_key = "fk_rails_90a03e3955"
     defer_constraint_until_commit! postcode_local_authority_foreign_key
-    defer_constraint_until_commit! office_local_authority_foreign_key
     defer_constraint_until_commit! served_areas_local_authority_foreign_key
   end
 
+  # - we rely on database validations
   def nullify_dangling_offices!(current_local_authority_ids)
-    # rubocop:disable Rails/SkipsModelValidations - we rely on database validations
-    Office.where.not(local_authority_id: current_local_authority_ids).update_all(local_authority_id: nil)
     ServedArea.where.not(local_authority_id: current_local_authority_ids).delete_all
-    # rubocop:enable Rails/SkipsModelValidations
   end
 
   def postcode_csv_has_expected_headers?

--- a/spec/lss_loader_spec.rb
+++ b/spec/lss_loader_spec.rb
@@ -238,7 +238,6 @@ RSpec.describe LssLoader do
   def expect_single_record(vals)
     vals = {
       parent_id: nil,
-      local_authority_id: nil,
       legacy_id: nil,
       membership_number: nil,
       company_number: nil,

--- a/spec/lss_loader_spec.rb
+++ b/spec/lss_loader_spec.rb
@@ -161,13 +161,6 @@ RSpec.describe LssLoader do
     expect(Office.find("0014K00000an3g3QAA").parent_id).to be_nil
   end
 
-  it "loads in local authority IDs on advice locations" do
-    LocalAuthority.create! id: "E06000023", name: "Bristol, City of"
-    load_from_fixtures locations_csv_filename: "has_local_authority"
-
-    expect(Office.find("0014K000009EMMbQAO").local_authority_id).to eq("E06000023")
-  end
-
   it "loads in local authority IDs on advice locations into the served areas table" do
     LocalAuthority.create! id: "E06000023", name: "Bristol, City of"
     load_from_fixtures locations_csv_filename: "has_local_authority"
@@ -199,16 +192,9 @@ RSpec.describe LssLoader do
                          county: "Kent",
                          postcode: "CT20 1RH",
                          email: "cab@example.com",
-                         website: "www.shepwaycab.co.uk",
-                         local_authority_id: "E07000112"
+                         website: "www.shepwaycab.co.uk"
   end
   # rubocop:enable RSpec/ExampleLength
-
-  it "makes a dangling local authority ID null" do
-    load_from_fixtures members_csv_filename: "minimal"
-
-    expect(Office.find("0014K00000PcC94QAF").local_authority_id).to be_nil
-  end
 
   def create_a_single_office
     id = SecureRandom.hex(9)

--- a/spec/postcode_loader_spec.rb
+++ b/spec/postcode_loader_spec.rb
@@ -70,7 +70,8 @@ RSpec.describe PostcodeLoader do
 
     it "successfully renames a local authority when an LCA is assigned to it" do
       LocalAuthority.create! id: "S12000033", name: "City of Aberdeen"
-      Office.create! id: generate_salesforce_id, name: "Aberdeen CAB", office_type: "member", local_authority_id: "S12000033"
+      create_office_in_local_authority id: generate_salesforce_id, name: "Aberdeen CAB", office_type: "member",
+                                       local_authority_id: "S12000033"
 
       load_from_fixture "single"
 
@@ -80,11 +81,11 @@ RSpec.describe PostcodeLoader do
     it "successfully handles removal of a local authority when an LCA is assigned to it" do
       LocalAuthority.create! id: "X00000000", name: "Testtown City Council"
       office_id = generate_salesforce_id
-      Office.create! id: office_id, name: "Aberdeen CAB", office_type: "member", local_authority_id: "X00000000"
+      create_office_in_local_authority id: office_id, name: "Aberdeen CAB", office_type: "member", local_authority_id: "X00000000"
 
       load_from_fixture "single"
 
-      expect(Office.find(office_id).local_authority_id).to be_nil
+      expect(Office.find(office_id).served_areas).to be_empty
     end
   end
 
@@ -103,5 +104,11 @@ RSpec.describe PostcodeLoader do
         LocalAuthority.create!(id: "A#{SecureRandom.hex(4)}", name: "Testtown").id
     end
     Postcode.create!({ location: "POINT(0.7 51.3)" }.update(vals))
+  end
+
+  def create_office_in_local_authority(local_authority_id:, **office_vals)
+    office = Office.create!(**office_vals)
+    ServedArea.create!(office_id: office.id, local_authority_id:)
+    office
   end
 end


### PR DESCRIPTION
This is the final step on the journey for refactoring the database to allow an office to serve multiple local authority areas. https://github.com/citizensadvice/local-office-search-api/pull/174 changed the logic to no longer use the old attribute, so we can stop setting it in the importer, and once that's deployed, the migration can run to remove the now unused column in the table.

The final piece of this overall puzzle will be updating the importer once the data science team starts providing the information on alternative Local Authorities to us.