### PR TITLE
strip trailing/leading whitespace on fuzzy location matching

### DIFF
--- a/lib/office_search.rb
+++ b/lib/office_search.rb
@@ -59,7 +59,7 @@ module OfficeSearch
   end
 
   def self.by_fuzzy_location(near, opts)
-    fuzzy_query = build_fuzzy_query(near, opts)
+    fuzzy_query = build_fuzzy_query(normalise_fuzzy_term(near), opts)
     raise UnknownLocationError if fuzzy_query.empty?
 
     fuzzy_query
@@ -72,5 +72,9 @@ module OfficeSearch
     q = q.where(office_type: :office)
     q = q.where.not(volunteer_roles: []) if opts[:only_with_vacancies]
     q.limit(10)
+  end
+
+  def self.normalise_fuzzy_term(near)
+    near.strip
   end
 end

--- a/spec/office_search_spec.rb
+++ b/spec/office_search_spec.rb
@@ -34,6 +34,16 @@ RSpec.describe OfficeSearch do
     expect(results.pluck(:id)).to contain_exactly(other_office.id)
   end
 
+  it "normalises the fuzzy match to trim whitespace" do
+    office = create_office_with_local_authority
+    other_office = create_office_in_local_authority name: "Anotherville Citizens Advice",
+                                                    local_authority_id: office.served_areas.first.local_authority_id
+
+    results, = described_class.by_location(" anotherville ")
+
+    expect(results.pluck(:id)).to contain_exactly(other_office.id)
+  end
+
   it "returns both a mix of if the office name matches and if the local authority matches" do
     office = create_office_with_local_authority
     other_office = create_office name: "Testtown Citizens Advice"


### PR DESCRIPTION
sometimes autocomplete can leave a search field with trailing whitespace, which then gets included in the search criteria and results in no matches if a place is a single word. This removes leading/trailing whitespace in the fuzzy match to avoid more false negatives.