### PR TITLE
allow looking up office IDs case insensitively

### DIFF
--- a/app/controllers/api/v2/office_controller.rb
+++ b/app/controllers/api/v2/office_controller.rb
@@ -59,11 +59,14 @@ module Api
       end
 
       def fetch_and_render_office
-        office = Office.find(params[:id])
-      rescue ActiveRecord::RecordNotFound
-        render status: :not_found, json: not_found_json
-      else
-        render json: office_as_json(office)
+        office = Office.find_by("lower(id) = ?", params[:id].downcase)
+        if office.nil?
+          render status: :not_found, json: not_found_json
+        elsif params[:id] == office.id
+          render json: office_as_json(office)
+        else
+          redirect_to api_v2_office_url(office)
+        end
       end
 
       def redirect_from_legacy_id_to_new

--- a/db/migrate/20241120112748_allow_case_insensitive_office_ids.rb
+++ b/db/migrate/20241120112748_allow_case_insensitive_office_ids.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AllowCaseInsensitiveOfficeIds < ActiveRecord::Migration[7.2]
+  def change
+    add_index(:offices, "lower(id)", unique: true)
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -394,6 +394,13 @@ CREATE INDEX index_offices_on_legacy_id ON public.offices USING btree (legacy_id
 
 
 --
+-- Name: index_offices_on_lower_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_offices_on_lower_id ON public.offices USING btree (lower((id)::text));
+
+
+--
 -- Name: index_offices_on_membership_number_and_office_type; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -489,6 +496,7 @@ ALTER TABLE ONLY public.offices
 SET search_path TO "$user", public, topology, tiger;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20241120112748'),
 ('20240904130334'),
 ('20240813152802'),
 ('20231120143230'),

--- a/spec/requests/v2/office_spec.rb
+++ b/spec/requests/v2/office_spec.rb
@@ -120,14 +120,27 @@ RSpec.describe "Lookup Local Office API", swagger_doc: "v2/swagger.yaml" do
         # rubocop:enable RSpec/ExampleLength
       end
 
-      response "302", "Allows you to look up an office by its resource directory ID and redirect to canonical ID" do
-        let(:office) do
-          Office.create({ id: generate_salesforce_id, office_type: :office, name: "Testtown CAB", legacy_id: 1234 })
-        end
-        let(:id) { office.legacy_id }
+      response "302", "redirects you to the canonical ID" do
+        context "when the legacy resource directory ID is specified" do
+          let(:office) do
+            Office.create({ id: generate_salesforce_id, office_type: :office, name: "Testtown CAB", legacy_id: 1234 })
+          end
+          let(:id) { office.legacy_id }
 
-        run_test! do |response|
-          expect(response.location).to eq("http://www.example.com/api/v2/offices/#{office.id}")
+          run_test! do |response|
+            expect(response.location).to eq("http://www.example.com/api/v2/offices/#{office.id}")
+          end
+        end
+
+        context "when a case-insensitive string is specified" do
+          let(:office) do
+            Office.create({ id: "0014K000009EMPHQA4", office_type: :office, name: "Testtown CAB" })
+          end
+          let(:id) { office.id.downcase }
+
+          run_test! do |response|
+            expect(response.location).to eq("http://www.example.com/api/v2/offices/0014K000009EMPHQA4")
+          end
         end
       end
 


### PR DESCRIPTION
public-website already knows how to handle redirects (for redirecting from legacy resource directory IDs to the new canonical Salesforce IDs) so it will transparently redirect the user if it gets a redirect from the API.

Salesforce IDs are cased, but in the 18 character version, they are guaranteed to be case-insensitively unique. https://help.salesforce.com/s/articleView?language=en_US&id=000385008&type=1