### PR TITLE
add charity and company number for offices (required for local office minisites)

### DIFF
--- a/app/controllers/api/v2/serialisers.rb
+++ b/app/controllers/api/v2/serialisers.rb
@@ -7,9 +7,10 @@ module Api
         office.as_json(only: %i[id name about_text accessibility_information street city county postcode location email website phone
                                 allows_drop_ins]).tap do |json|
           json[:type] = office.office_type
+
           json[:relations] = build_relations_json(office)
-          json[:opening_hours] = opening_times_as_json(office.opening_hours_information, office.opening_hours)
-          json[:telephone_advice_hours] = opening_times_as_json(office.telephone_advice_hours_information, office.telephone_advice_hours)
+          json.update opening_time_fields(office)
+          json.update fields_for_members(office) if office.office_type == "member"
         end
       end
 
@@ -70,6 +71,17 @@ module Api
           end
         end
         opening_times
+      end
+
+      def opening_time_fields(office)
+        {
+          opening_hours: opening_times_as_json(office.opening_hours_information, office.opening_hours),
+          telephone_advice_hours: opening_times_as_json(office.telephone_advice_hours_information, office.telephone_advice_hours)
+        }
+      end
+
+      def fields_for_members(office)
+        office.slice(:charity_number, :company_number)
       end
 
       def contact_methods(office)

--- a/spec/requests/v2/schema.rb
+++ b/spec/requests/v2/schema.rb
@@ -93,7 +93,9 @@ module ApiV2Schema
       allows_drop_ins: { type: :boolean },
       opening_hours: OPENING_HOURS,
       telephone_advice_hours: OPENING_HOURS,
-      relations: { type: :array, items: RELATED_OBJECT }
+      relations: { type: :array, items: RELATED_OBJECT },
+      charity_number: { type: NULLABLE_STRING },
+      company_number: { type: NULLABLE_STRING }
     },
     required: %i[id name about_text accessibility_information street city postcode location email website phone
                  allows_drop_ins opening_hours telephone_advice_hours relations],

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -8,11 +8,6 @@ RSpec.configure do |config|
   # to ensure that it's configured to serve Swagger from the same folder
   config.openapi_root = Rails.root.join("swagger").to_s
 
-  # By default, if response body contains undocumented properties tests will pass.
-  # To keep your responses clean and validate against a strict schema definition
-  # you can set the global config option:
-  config.openapi_strict_schema_validation = true
-
   # Define one or more Swagger documents and provide global metadata for each one
   # When you run the 'rswag:specs:swaggerize' rake task, the complete Swagger will
   # be generated at the provided relative path under swagger_root

--- a/swagger/v2/swagger.yaml
+++ b/swagger/v2/swagger.yaml
@@ -375,6 +375,14 @@ paths:
                       - type
                       - name
                       additionalProperties: false
+                  charity_number:
+                    type:
+                    - string
+                    - 'null'
+                  company_number:
+                    type:
+                    - string
+                    - 'null'
                 required:
                 - id
                 - name
@@ -393,8 +401,7 @@ paths:
                 - relations
                 additionalProperties: false
         '302':
-          description: Allows you to look up an office by its resource directory ID
-            and redirect to canonical ID
+          description: redirects you to the canonical ID
         '404':
           description: No office with this ID
           content:
@@ -1042,6 +1049,14 @@ paths:
                           - type
                           - name
                           additionalProperties: false
+                      charity_number:
+                        type:
+                        - string
+                        - 'null'
+                      company_number:
+                        type:
+                        - string
+                        - 'null'
                     required:
                     - id
                     - name


### PR DESCRIPTION
This also removes the default strict setting from rswag. This is because the strictness is set in the schema itself, and this was clashing with the addition of optional member only fields.