### PR TITLE
NAT-1398: change deployment mechanism to resolve high availability issues

### DIFF
--- a/cdk/app/chart.py
+++ b/cdk/app/chart.py
@@ -35,6 +35,8 @@ from cdk8s_plus_32 import (
     Secret,
     ServiceAccount,
     ServiceType,
+    ContainerLifecycle,
+    Handler,
 )
 from ca_cdk8s_constructs.pod_disruption_budget import ca_pod_disruption_budget
 from constructs import Construct
@@ -214,6 +216,7 @@ class LocalOfficeSearchApiChart(Chart):
                 failure_threshold=3,
                 timeout_seconds=Duration.seconds(5),
             ),
+            lifecycle=ContainerLifecycle(pre_stop=Handler.from_command(["sleep", "10"])),
             resources=ContainerResources(
                 cpu=CpuResources(request=Cpu.millis(400), limit=Cpu.millis(800)),
                 memory=MemoryResources(request=Size.mebibytes(512), limit=Size.gibibytes(1)),

--- a/cdk/app/chart.py
+++ b/cdk/app/chart.py
@@ -74,6 +74,7 @@ class LocalOfficeSearchApiChart(Chart):
             construct_id,
             namespace=namespace,
             labels=self._labels,
+            disable_resource_name_hashes=True, # this was needed to migrate from plain cdk8s to one wrapped in Helm, as this had name clashes
         )
 
         self._container_image = f"{image_repo.repository_uri}:{image_version}"
@@ -95,7 +96,7 @@ class LocalOfficeSearchApiChart(Chart):
         self._geo_data_postcode_file = geo_data_postcode_file
 
         deployment = self._create_deployment()
-        # self._expose_services(deployment)
+        self._expose_services(deployment)
 
         self._create_scheduled_import()
         self._configure_autoscaler(deployment)

--- a/cdk/app/chart.py
+++ b/cdk/app/chart.py
@@ -36,6 +36,7 @@ from cdk8s_plus_32 import (
     ServiceAccount,
     ServiceType,
 )
+from ca_cdk8s_constructs.pod_disruption_budget import ca_pod_disruption_budget
 from constructs import Construct
 
 
@@ -96,6 +97,7 @@ class LocalOfficeSearchApiChart(Chart):
         self._geo_data_postcode_file = geo_data_postcode_file
 
         deployment = self._create_deployment()
+        ca_pod_disruption_budget(self, "LocalOfficeSearchApiPdb", deployment)
         self._expose_services(deployment)
 
         self._create_scheduled_import()

--- a/cdk/app/local_office_search_api.py
+++ b/cdk/app/local_office_search_api.py
@@ -9,6 +9,7 @@ from ca_cdk_constructs.eks.external_secrets import (
     ExternalAwsSecretsChart,
     ExternalSecretSource,
 )
+from ca_cdk8s_constructs.cdk8s_helm_chart import Cdk8sHelmChart
 from constructs import Construct
 
 from cdk8s import App
@@ -123,9 +124,13 @@ class LocalOfficeSearchApiDeployment(Stack):
             ),
         )
 
-        eks_cluster.add_cdk8s_chart(
-            "LocalOfficeSearchApiChart",
-            LocalOfficeSearchApiChart(
+        Cdk8sHelmChart(
+            self,
+            "LocalOfficeSearchApiHelmChart",
+            chart_name="local-office-search-api",
+            app_version=app_image_version,
+            cluster=eks_cluster,
+            cdk8s_chart=LocalOfficeSearchApiChart(
                 self._cdk8s_app,
                 "LocalOfficeSearchApiChart",
                 namespace=namespace,
@@ -141,5 +146,6 @@ class LocalOfficeSearchApiDeployment(Stack):
                 rds_secret_name=rds_secret_source.k8s_secret_name,
                 app_secret_name=app_secret_source.k8s_secret_name,
             ),
-            prune=False
+            atomic=True,
+            create_namespace=False,
         )

--- a/cdk/app/local_office_search_api.py
+++ b/cdk/app/local_office_search_api.py
@@ -126,7 +126,7 @@ class LocalOfficeSearchApiDeployment(Stack):
 
         Cdk8sHelmChart(
             self,
-            "LocalOfficeSearchApiHelmChart",
+            "LocalOfficeSearchApiChart",
             chart_name="local-office-search-api",
             app_version=app_image_version,
             cluster=eks_cluster,

--- a/cdk/poetry.lock
+++ b/cdk/poetry.lock
@@ -22,18 +22,18 @@ tests-mypy = ["mypy (>=1.11.1) ; platform_python_implementation == \"CPython\" a
 
 [[package]]
 name = "aws-cdk-asset-awscli-v1"
-version = "2.2.228"
+version = "2.2.236"
 description = "A library that contains the AWS CLI for use in Lambda Layers"
 optional = false
 python-versions = "~=3.9"
 groups = ["main"]
 files = [
-    {file = "aws_cdk.asset_awscli_v1-2.2.228-py3-none-any.whl", hash = "sha256:a79a76948a32e672c5f0743384c5abea14ee8b802b4a080f63a1f310fd7d5861"},
-    {file = "aws_cdk_asset_awscli_v1-2.2.228.tar.gz", hash = "sha256:65def76adc852eb9fdab16ebe1b9193ce9892546fdb13ab0d0c3211c220887cc"},
+    {file = "aws_cdk_asset_awscli_v1-2.2.236-py3-none-any.whl", hash = "sha256:c14e64538af61d99cf37e01e65f8ba549949536052fe5a5fc8b56eaf1a0c714e"},
+    {file = "aws_cdk_asset_awscli_v1-2.2.236.tar.gz", hash = "sha256:5e1c907cfc81f09c2af229ac2af3e9cbbbe8c476a50481b4097d6aa7d3e5330d"},
 ]
 
 [package.dependencies]
-jsii = ">=1.109.0,<2.0.0"
+jsii = ">=1.111.0,<2.0.0"
 publication = ">=0.0.3"
 typeguard = ">=2.13.3,<4.3.0"
 
@@ -56,14 +56,14 @@ typeguard = ">=2.13.3,<5.0.0"
 
 [[package]]
 name = "aws-cdk-cloud-assembly-schema"
-version = "40.7.0"
+version = "41.2.0"
 description = "Schema for the protocol between CDK framework and CDK CLI"
 optional = false
 python-versions = "~=3.8"
 groups = ["main"]
 files = [
-    {file = "aws_cdk.cloud_assembly_schema-40.7.0-py3-none-any.whl", hash = "sha256:a86de4f46a72f9445f0a0ae646c348702041047c72d10b76e3b4c8dc5e460ee1"},
-    {file = "aws_cdk_cloud_assembly_schema-40.7.0.tar.gz", hash = "sha256:8269a74cce261e56750290a2492f04d0e6825913d321a8ab17ba3b5f872fc193"},
+    {file = "aws_cdk.cloud_assembly_schema-41.2.0-py3-none-any.whl", hash = "sha256:779ca7e3edb02695e0a94a1f38e322b04fbe192cd7944553f80b681a21edd670"},
+    {file = "aws_cdk_cloud_assembly_schema-41.2.0.tar.gz", hash = "sha256:7064ac13f6944fd53f8d8eace611d3c5d8db7014049d629f5c47ede8dc5f2e3b"},
 ]
 
 [package.dependencies]
@@ -72,48 +72,48 @@ publication = ">=0.0.3"
 typeguard = ">=2.13.3,<4.3.0"
 
 [[package]]
-name = "aws-cdk-lambda-layer-kubectl-v29"
-version = "2.1.1"
-description = "A Lambda Layer that contains kubectl v1.29"
+name = "aws-cdk-lambda-layer-kubectl-v32"
+version = "2.1.0"
+description = "A Lambda Layer that contains kubectl v1.32"
 optional = false
-python-versions = "~=3.8"
+python-versions = "~=3.9"
 groups = ["main"]
 files = [
-    {file = "aws_cdk.lambda_layer_kubectl_v29-2.1.1-py3-none-any.whl", hash = "sha256:b6496fc9bc7e3e1d56e45328e4fc878c010a1e340a1039c639aacbd7395fe2e0"},
-    {file = "aws_cdk_lambda_layer_kubectl_v29-2.1.1.tar.gz", hash = "sha256:6a3dee8036ea04e26f5f56242c1b91a099b00babb6ab0810b2e46deff59f7355"},
+    {file = "aws_cdk_lambda_layer_kubectl_v32-2.1.0-py3-none-any.whl", hash = "sha256:dd44f22292e8e31b48bcd9edd8afe918ca2669abfa781a4fa169c84a69fe2f22"},
+    {file = "aws_cdk_lambda_layer_kubectl_v32-2.1.0.tar.gz", hash = "sha256:5e854b759975827cdeb8edb0fdd8736d2d1c3c0eb3dd9715975e35923172948e"},
 ]
 
 [package.dependencies]
 aws-cdk-lib = ">=2.94.0,<3.0.0"
 constructs = ">=10.0.5,<11.0.0"
-jsii = ">=1.106.0,<2.0.0"
+jsii = ">=1.110.0,<2.0.0"
 publication = ">=0.0.3"
 typeguard = ">=2.13.3,<4.3.0"
 
 [[package]]
 name = "aws-cdk-lib"
-version = "2.185.0"
+version = "2.195.0"
 description = "Version 2 of the AWS Cloud Development Kit library"
 optional = false
 python-versions = "~=3.9"
 groups = ["main"]
 files = [
-    {file = "aws_cdk_lib-2.185.0-py3-none-any.whl", hash = "sha256:e58db294db7265962a7122319b708fce1815e0e5b46451d93bac9789ad33a798"},
-    {file = "aws_cdk_lib-2.185.0.tar.gz", hash = "sha256:d96216f444d9560e4f8b0cfd7f25b84c66b8570a264bead8142f40261425e24e"},
+    {file = "aws_cdk_lib-2.195.0-py3-none-any.whl", hash = "sha256:9087fca8dbe5cf256cdcbf00f0c6e452ceeb66452aea5878728633a379e7aa56"},
+    {file = "aws_cdk_lib-2.195.0.tar.gz", hash = "sha256:6617bc60dc1e37826f16d8932df73e6a062922cef12bf11e9f12becbdda73f33"},
 ]
 
 [package.dependencies]
-"aws-cdk.asset-awscli-v1" = ">=2.2.227,<3.0.0"
+"aws-cdk.asset-awscli-v1" = ">=2.2.229,<3.0.0"
 "aws-cdk.asset-node-proxy-agent-v6" = ">=2.1.0,<3.0.0"
-"aws-cdk.cloud-assembly-schema" = ">=40.7.0,<41.0.0"
+"aws-cdk.cloud-assembly-schema" = ">=41.2.0,<42.0.0"
 constructs = ">=10.0.0,<11.0.0"
-jsii = ">=1.109.0,<2.0.0"
+jsii = ">=1.110.0,<2.0.0"
 publication = ">=0.0.3"
 typeguard = ">=2.13.3,<4.3.0"
 
 [[package]]
 name = "ca-cdk-constructs"
-version = "0.9.0"
+version = "0.13.0"
 description = "Shared CDK constructs"
 optional = false
 python-versions = ">=3.10, <3.13"
@@ -122,28 +122,50 @@ files = []
 develop = false
 
 [package.dependencies]
-aws-cdk-lambda-layer-kubectl-v29 = "^2.0.0"
-aws-cdk-lib = "~=2.122"
-cdk_remote_stack = "~=2.0"
-cdk8s-plus-26 = "~=2.18"
-constructs = "~=10.1"
+aws-cdk-lambda-layer-kubectl-v32 = "^2.0.3"
+aws-cdk-lib = "~=2.181"
+cdk_remote_stack = "~=2.1"
+cdk8s = "~2.69.47"
+constructs = "~=10.4"
 
 [package.source]
 type = "git"
 url = "https://github.com/citizensadvice/ca-cdk-constructs"
-reference = "v0.9.0"
-resolved_reference = "2d00028b5b2458dd1211d825abc5d58a5ed41e90"
+reference = "v0.13.0"
+resolved_reference = "b18d1d41b22d64f91fb17ca0b13f0dbdc681bed1"
+
+[[package]]
+name = "ca-cdk8s-constructs"
+version = "2.3.0"
+description = "A collection of cdk8s constructs"
+optional = false
+python-versions = ">=3.10, <3.14"
+groups = ["main"]
+files = []
+develop = false
+
+[package.dependencies]
+aws-cdk-lib = "^2.190.0"
+cdk8s = "~2.69.5"
+cdk8s-plus-32 = "^2.0.11"
+pyyaml = "^6.0.2"
+
+[package.source]
+type = "git"
+url = "https://github.com/citizensadvice/ca-cdk8s-constructs"
+reference = "v2.3.0"
+resolved_reference = "76503f70499a986b2ba6a219d0d0c05e0ea1462f"
 
 [[package]]
 name = "cattrs"
-version = "24.1.2"
+version = "24.1.3"
 description = "Composable complex class support for attrs and dataclasses."
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "cattrs-24.1.2-py3-none-any.whl", hash = "sha256:67c7495b760168d931a10233f979b28dc04daf853b30752246f4f8471c6d68d0"},
-    {file = "cattrs-24.1.2.tar.gz", hash = "sha256:8028cfe1ff5382df59dd36474a86e02d817b06eaf8af84555441bac915d2ef85"},
+    {file = "cattrs-24.1.3-py3-none-any.whl", hash = "sha256:adf957dddd26840f27ffbd060a6c4dd3b2192c5b7c2c0525ef1bd8131d8a83f5"},
+    {file = "cattrs-24.1.3.tar.gz", hash = "sha256:981a6ef05875b5bb0c7fb68885546186d306f10f0f6718fe9b96c226e68821ff"},
 ]
 
 [package.dependencies]
@@ -182,40 +204,21 @@ typeguard = ">=2.13.3,<2.14.0"
 
 [[package]]
 name = "cdk8s"
-version = "2.69.55"
+version = "2.69.67"
 description = "This is the core library of Cloud Development Kit (CDK) for Kubernetes (cdk8s). cdk8s apps synthesize into standard Kubernetes manifests which can be applied to any Kubernetes cluster."
 optional = false
 python-versions = "~=3.9"
 groups = ["main"]
 files = [
-    {file = "cdk8s-2.69.55-py3-none-any.whl", hash = "sha256:adc26f4b53434e89a4c3189c1589fbeed4bbc2785fa4803942dbc0747cdbbe5e"},
-    {file = "cdk8s-2.69.55.tar.gz", hash = "sha256:324f20e03b71c527d4933a234746c1ecc4f1a824652cabe22750193b8b73dd87"},
+    {file = "cdk8s-2.69.67-py3-none-any.whl", hash = "sha256:e65a450d7054e469f1a2377a1a8f85fed4212e37e74e3503c5826e4d3dffcdbb"},
+    {file = "cdk8s-2.69.67.tar.gz", hash = "sha256:4efd3f0a533f220301f35d843cfecaaf9b29b38a10abf0aa00afc78620837b31"},
 ]
 
 [package.dependencies]
 constructs = ">=10.0.0,<11.0.0"
-jsii = ">=1.110.0,<2.0.0"
+jsii = ">=1.112.0,<2.0.0"
 publication = ">=0.0.3"
 typeguard = ">=2.13.3,<4.3.0"
-
-[[package]]
-name = "cdk8s-plus-26"
-version = "2.18.90"
-description = "cdk8s+ is a software development framework that provides high level abstractions for authoring Kubernetes applications. cdk8s-plus-26 synthesizes Kubernetes manifests for Kubernetes 1.26.0"
-optional = false
-python-versions = "~=3.8"
-groups = ["main"]
-files = [
-    {file = "cdk8s-plus-26-2.18.90.tar.gz", hash = "sha256:e18c4780c4503a282cef85649b1a092db93d6883facc120f30ac35257493d577"},
-    {file = "cdk8s_plus_26-2.18.90-py3-none-any.whl", hash = "sha256:72a3be11cbeb005ba553867df961ff645db7760a9bb1298e2fd29e75f992e2a2"},
-]
-
-[package.dependencies]
-cdk8s = ">=2.68.11,<3.0.0"
-constructs = ">=10.3.0,<11.0.0"
-jsii = ">=1.97.0,<2.0.0"
-publication = ">=0.0.3"
-typeguard = ">=2.13.3,<2.14.0"
 
 [[package]]
 name = "cdk8s-plus-32"
@@ -268,16 +271,19 @@ typeguard = ">=2.13.3,<2.14.0"
 
 [[package]]
 name = "exceptiongroup"
-version = "1.2.2"
+version = "1.3.0"
 description = "Backport of PEP 654 (exception groups)"
 optional = false
 python-versions = ">=3.7"
 groups = ["main", "dev"]
 markers = "python_version < \"3.11\""
 files = [
-    {file = "exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b"},
-    {file = "exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"},
+    {file = "exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10"},
+    {file = "exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88"},
 ]
+
+[package.dependencies]
+typing-extensions = {version = ">=4.6.0", markers = "python_version < \"3.13\""}
 
 [package.extras]
 test = ["pytest (>=6)"]
@@ -337,14 +343,14 @@ typing_extensions = ">=3.8,<5.0"
 
 [[package]]
 name = "packaging"
-version = "24.2"
+version = "25.0"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"},
-    {file = "packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"},
+    {file = "packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484"},
+    {file = "packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"},
 ]
 
 [[package]]
@@ -412,6 +418,69 @@ files = [
 
 [package.dependencies]
 six = ">=1.5"
+
+[[package]]
+name = "pyyaml"
+version = "6.0.2"
+description = "YAML parser and emitter for Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "PyYAML-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086"},
+    {file = "PyYAML-6.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf"},
+    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237"},
+    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b"},
+    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed"},
+    {file = "PyYAML-6.0.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180"},
+    {file = "PyYAML-6.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68"},
+    {file = "PyYAML-6.0.2-cp310-cp310-win32.whl", hash = "sha256:2e99c6826ffa974fe6e27cdb5ed0021786b03fc98e5ee3c5bfe1fd5015f42b99"},
+    {file = "PyYAML-6.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:a4d3091415f010369ae4ed1fc6b79def9416358877534caf6a0fdd2146c87a3e"},
+    {file = "PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774"},
+    {file = "PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee"},
+    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c"},
+    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317"},
+    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85"},
+    {file = "PyYAML-6.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4"},
+    {file = "PyYAML-6.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e"},
+    {file = "PyYAML-6.0.2-cp311-cp311-win32.whl", hash = "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5"},
+    {file = "PyYAML-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44"},
+    {file = "PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab"},
+    {file = "PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725"},
+    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5"},
+    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425"},
+    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476"},
+    {file = "PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48"},
+    {file = "PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b"},
+    {file = "PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4"},
+    {file = "PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8"},
+    {file = "PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba"},
+    {file = "PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1"},
+    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133"},
+    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484"},
+    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5"},
+    {file = "PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc"},
+    {file = "PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652"},
+    {file = "PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183"},
+    {file = "PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563"},
+    {file = "PyYAML-6.0.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:24471b829b3bf607e04e88d79542a9d48bb037c2267d7927a874e6c205ca7e9a"},
+    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d7fded462629cfa4b685c5416b949ebad6cec74af5e2d42905d41e257e0869f5"},
+    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d84a1718ee396f54f3a086ea0a66d8e552b2ab2017ef8b420e92edbc841c352d"},
+    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9056c1ecd25795207ad294bcf39f2db3d845767be0ea6e6a34d856f006006083"},
+    {file = "PyYAML-6.0.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:82d09873e40955485746739bcb8b4586983670466c23382c19cffecbf1fd8706"},
+    {file = "PyYAML-6.0.2-cp38-cp38-win32.whl", hash = "sha256:43fa96a3ca0d6b1812e01ced1044a003533c47f6ee8aca31724f78e93ccc089a"},
+    {file = "PyYAML-6.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:01179a4a8559ab5de078078f37e5c1a30d76bb88519906844fd7bdea1b7729ff"},
+    {file = "PyYAML-6.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:688ba32a1cffef67fd2e9398a2efebaea461578b0923624778664cc1c914db5d"},
+    {file = "PyYAML-6.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a8786accb172bd8afb8be14490a16625cbc387036876ab6ba70912730faf8e1f"},
+    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8e03406cac8513435335dbab54c0d385e4a49e4945d2909a581c83647ca0290"},
+    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12"},
+    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19"},
+    {file = "PyYAML-6.0.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0b69e4ce7a131fe56b7e4d770c67429700908fc0752af059838b1cfb41960e4e"},
+    {file = "PyYAML-6.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a9f8c2e67970f13b16084e04f134610fd1d374bf477b17ec1599185cf611d725"},
+    {file = "PyYAML-6.0.2-cp39-cp39-win32.whl", hash = "sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631"},
+    {file = "PyYAML-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8"},
+    {file = "pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e"},
+]
 
 [[package]]
 name = "ruff"
@@ -514,17 +583,18 @@ test = ["mypy ; platform_python_implementation != \"PyPy\"", "pytest", "typing-e
 
 [[package]]
 name = "typing-extensions"
-version = "4.12.2"
+version = "4.13.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
-    {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
-    {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
+    {file = "typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c"},
+    {file = "typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef"},
 ]
+markers = {dev = "python_version < \"3.11\""}
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.13"
-content-hash = "f28e088e868f51dd80210ea3604349a9bef8ab36933cdca0d6f7ab5539a90765"
+content-hash = "8fe1e4e78d94f3795fefb98e0b01fd42925ee69dfebbaeb79ad4f3eaa3f62501"

--- a/cdk/pyproject.toml
+++ b/cdk/pyproject.toml
@@ -8,7 +8,8 @@ package-mode = false
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.13"
-ca-cdk-constructs = {git = "https://github.com/citizensadvice/ca-cdk-constructs", rev = "v0.9.0"}
+ca-cdk-constructs = {git = "https://github.com/citizensadvice/ca-cdk-constructs", rev = "v0.13.0"}
+ca-cdk8s-constructs = { git = "https://github.com/citizensadvice/ca-cdk8s-constructs", rev = "v2.3.0" }
 ruff = "^0.11.9"
 cdk8s-plus-32 = "^2.1.1"
 


### PR DESCRIPTION
This implements the changes described [in this ADR](https://github.com/citizensadvice/content-api/blob/develop/docs/architecture-decisions/0006-deploy-content-api-as-cdk8s-wrapped-helm-chart.md) as well as introducing other issues raised by SRE such as the lack of a PDB and the pre-stop hook recommended by Puma.