### PR TITLE
chore: increasing the memory requests

### DIFF
--- a/cdk/app/chart.py
+++ b/cdk/app/chart.py
@@ -222,7 +222,7 @@ class LocalOfficeSearchApiChart(Chart):
             lifecycle=ContainerLifecycle(pre_stop=Handler.from_command(["sleep", "10"])),
             resources=ContainerResources(
                 cpu=CpuResources(request=Cpu.millis(400), limit=Cpu.millis(800)),
-                memory=MemoryResources(request=Size.mebibytes(512), limit=Size.gibibytes(1)),
+                memory=MemoryResources(request=Size.mebibytes(768), limit=Size.gibibytes(1)),
             ),
             security_context=ContainerSecurityContextProps(
                 user=1000, read_only_root_filesystem=False


### PR DESCRIPTION
In our dev env, the scheduledimport job often exceeds the memory requests without reaching the limit so we need to increase the requests to closer match what's required.