### PR TITLE
chore: update python-poetry-setup-action to latest SHA

### DIFF
--- a/.github/workflows/cdk_diff.yml
+++ b/.github/workflows/cdk_diff.yml
@@ -22,7 +22,7 @@ jobs:
           aws-region: eu-west-1
           role-session-name: local-office-search-api-actions-workflow
 
-      - uses: citizensadvice/python-poetry-setup-action@792f824e452775c9732aa54e590f516a55f79946
+      - uses: citizensadvice/python-poetry-setup-action@a1b420d0c061560845532d7d1f80a81c8f39b6a5
         with:
           install_cdk: true
           project_root: "./cdk"

--- a/.github/workflows/deploy_stage.yml
+++ b/.github/workflows/deploy_stage.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: citizensadvice/python-poetry-setup-action@792f824e452775c9732aa54e590f516a55f79946
+      - uses: citizensadvice/python-poetry-setup-action@a1b420d0c061560845532d7d1f80a81c8f39b6a5
         with:
           install_cdk: true
           project_root: "./cdk"


### PR DESCRIPTION
The currently pinned version of this action uses a Node.js runtime that has reached End of Life. This update pins to the latest release which uses a supported Node.js version.